### PR TITLE
fix: reframe concept model as self-contained, not ontology-derived

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -139,7 +139,7 @@ onUnmounted(() => {
         </div>
         <div class="hero-tagline">
           Build multilingual concept systems with ISO-standard rigor.
-          One concept, many language designations, typed relationships, and semantic web export.
+          One concept, many language designations, typed relationships, and multi-format export.
         </div>
         <div class="hero-actions">
           <a href="/docs/model/" class="btn btn-primary">
@@ -181,7 +181,7 @@ onUnmounted(() => {
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
           </div>
           <h4>1. Model</h4>
-          <p>Define your concept system using the rich Glossarist domain model — {{ st.classes }} ontology classes, {{ st.relationships }} relationship types, {{ st.designations }} designation types, SHACL validation shapes.</p>
+          <p>Define your concept system using the rich Glossarist domain model — {{ st.classes }} entity types, {{ st.relationships }} relationship types, {{ st.designations }} designation types, validation shapes.</p>
           <a href="/docs/model/" class="pipeline-link">Concept Model &rarr;</a>
         </div>
         <div class="pipeline-connector">
@@ -310,13 +310,13 @@ onUnmounted(() => {
         <div class="model-card mc-onto">
           <div class="model-card-header">
             <span class="model-dot md-onto"></span>
-            <h3>Semantic Web & Linked Data</h3>
+            <h3>Formal Ontology</h3>
           </div>
-          <p class="model-card-desc">Formal ontology with SHACL shapes for validation. Aligned with SKOS, SKOS-XL, ISO 25964, PROV-O, and Dublin Core — ready for the linked data ecosystem.</p>
+          <p class="model-card-desc">The concept model is formally expressed as an OWL ontology with SHACL validation shapes. Interoperates with SKOS, SKOS-XL, ISO 25964, PROV-O, and Dublin Core for linked data integration.</p>
           <div class="model-card-fields">
-            <div class="field-row"><code>{{ st.classes }}</code><span>Ontology classes</span></div>
+            <div class="field-row"><code>{{ st.classes }}</code><span>Entity types</span></div>
             <div class="field-row"><code>{{ st.properties }}</code><span>Object &amp; datatype properties</span></div>
-            <div class="field-row"><code>{{ st.shapes }}</code><span>SHACL validation shapes</span></div>
+            <div class="field-row"><code>{{ st.shapes }}</code><span>Validation shapes</span></div>
           </div>
           <a href="/ontology" class="model-card-link">Browse ontology &rarr;</a>
         </div>

--- a/.vitepress/theme/components/ModelLanding.vue
+++ b/.vitepress/theme/components/ModelLanding.vue
@@ -23,7 +23,7 @@ const entities = [
   { href: '/docs/model/designations', dotColor: 'var(--g-teal)', title: 'Designations', desc: 'Designation types in a MECE hierarchy — expressions, abbreviations, symbols (letter and graphical), prefixes, and suffixes.', fields: ['expression', 'abbreviation', 'symbol', 'letter_symbol', 'graphical_symbol', 'prefix', 'suffix'] },
   { href: '/docs/model/relationships', dotColor: 'var(--g-shape)', title: 'Relationships', desc: 'Typed semantic links spanning 4 ISO standards — hierarchical, partitive, associative, equivalence, mapping, and spatiotemporal.', fields: ['broader/narrower', 'generic/partitive', 'exact_match', 'deprecates', 'and more'] },
   { href: '/docs/model/sources', dotColor: 'var(--g-taxonomy)', title: 'Sources', desc: 'Multi-level provenance tracking — authoritative and lineage sources with status tracking (identical, modified, restyled, generalisation).', fields: ['authoritative', 'lineage', 'status', 'origin', 'modification'] },
-  { href: '/ontology', dotColor: 'linear-gradient(135deg, var(--g-steel), var(--g-teal))', title: 'Semantic Web & Linked Data', desc: 'Formal ontology with SHACL shapes for validation. Aligned with SKOS, SKOS-XL, ISO 25964, PROV-O, and Dublin Core — ready for the linked data ecosystem.', fields: ['owl:Class', 'sh:Shape', 'skos:Concept', 'skosxl:Label'] },
+  { href: '/ontology', dotColor: 'linear-gradient(135deg, var(--g-steel), var(--g-teal))', title: 'Formal Ontology', desc: 'The concept model is formally expressed as an OWL ontology with SHACL validation shapes. Interoperates with SKOS, SKOS-XL, ISO 25964, PROV-O, and Dublin Core for linked data integration.', fields: ['owl:Class', 'sh:Shape', 'skos:Concept', 'skosxl:Label'] },
 ]
 </script>
 
@@ -33,7 +33,7 @@ const entities = [
     <div class="ml-stats">
       <div class="ml-stat">
         <span class="ml-stat-num">{{ st.classes }}</span>
-        <span class="ml-stat-label">Ontology Classes</span>
+        <span class="ml-stat-label">Entity Types</span>
       </div>
       <div class="ml-stat">
         <span class="ml-stat-num">{{ st.properties }}</span>
@@ -41,7 +41,7 @@ const entities = [
       </div>
       <div class="ml-stat">
         <span class="ml-stat-num">{{ st.shapes }}</span>
-        <span class="ml-stat-label">SHACL Shapes</span>
+        <span class="ml-stat-label">Validation Shapes</span>
       </div>
       <div class="ml-stat">
         <span class="ml-stat-num">{{ st.relationships }}</span>

--- a/.vitepress/theme/components/RelationshipTypes.vue
+++ b/.vitepress/theme/components/RelationshipTypes.vue
@@ -58,7 +58,7 @@ const alphabeticalList = computed(() =>
 <template>
   <div class="rt" v-if="loaded">
     <div class="rt-summary">
-      <span class="rt-count">{{ totalTypes }}</span> typed semantic relationship types in the Glossarist ontology.
+      <span class="rt-count">{{ totalTypes }}</span> typed semantic relationship types in the Glossarist concept model.
     </div>
 
     <!-- Category sections -->

--- a/.vitepress/theme/components/YamlSchemas.vue
+++ b/.vitepress/theme/components/YamlSchemas.vue
@@ -62,8 +62,7 @@ function toggleEntity(classId: string) {
     <!-- Entity schemas -->
     <div v-if="activeTab === 'entities'">
       <p class="ys-intro">
-        The YAML schema for each Glossarist entity type, rendered from its SHACL shape definition.
-        These shapes define the fields, types, and cardinality of every entity in a concept YAML file.
+        The YAML schema for each Glossarist entity type. The concept model is formally expressed as SHACL shapes for validation — these shapes define the fields, types, and cardinality of every entity in a concept YAML file.
       </p>
 
       <div v-for="entity in entitySchemas" :key="entity.classId" class="ys-entity">
@@ -138,7 +137,7 @@ function toggleEntity(classId: string) {
     <!-- Enumerations -->
     <div v-if="activeTab === 'enums'">
       <p class="ys-intro">
-        All enumerated value sets in the Glossarist model, rendered from the SKOS ConceptSchemes in the ontology.
+        All enumerated value sets in the Glossarist concept model. These are also available as SKOS ConceptSchemes in the ontology.
         These define the valid values for fields like <code>status</code>, <code>type</code>, and <code>normative_status</code>.
       </p>
 

--- a/about.md
+++ b/about.md
@@ -110,8 +110,9 @@ Glossarist is used in production by standards bodies including [ISO/TC 211 Geole
 1. **Adopt Glossarist** — Read the [Adoption Guide](/docs/adopt/)
 2. **Try the Desktop App** — [Download](/docs/software/desktop) and get started
 3. **Explore the Model** — Read the [Concept Model docs](/docs/model/)
-4. **Browse the Ontology** — Explore the [interactive ontology browser](/ontology)
-5. **View on GitHub** — Browse the [source code](https://github.com/glossarist)
+4. **Explore the Model** — Read the [Concept Model docs](/docs/model/)
+5. **Browse the Ontology** — Explore the [interactive OWL ontology browser](/ontology)
+6. **View on GitHub** — Browse the [source code](https://github.com/glossarist)
 
 ---
 

--- a/blog/2026-05-27-concept-model-v3.md
+++ b/blog/2026-05-27-concept-model-v3.md
@@ -1,6 +1,6 @@
 ---
 title: "Concept Model v3 — OWL ontology, SHACL shapes, and 14 SKOS concept schemes"
-description: "The Glossarist concept model v3 introduces an OWL ontology, SHACL shapes for validation, and 14 SKOS taxonomy concept schemes."
+description: "The Glossarist concept model v3 adds a formally defined OWL ontology, SHACL shapes for validation, and 14 SKOS taxonomy concept schemes — enabling interoperability with the semantic web ecosystem."
 authors:
   - Ribose
 date: 2026-05-27
@@ -8,11 +8,11 @@ date: 2026-05-27
 
 <BlogByline />
 
-The Glossarist concept model v3 brings formal semantic web integration to terminology management.
+The Glossarist concept model v3 adds a formally defined OWL ontology, SHACL validation shapes, and 14 SKOS taxonomy concept schemes — enabling interoperability with the semantic web and linked data ecosystem.
 
 ## OWL ontology
 
-The concept model now includes an [OWL ontology](https://github.com/glossarist/concept-model/tree/main/ontologies) that defines the complete class hierarchy:
+The concept model is now formally expressed as an [OWL ontology](https://github.com/glossarist/concept-model/tree/main/ontologies) that defines the complete class hierarchy:
 
 - `ManagedConcept` and `LocalizedConcept` as core classes
 - `Designation` hierarchy with subtypes (expression, abbreviation, symbol, letter_symbol, graphical_symbol, prefix, suffix)

--- a/blog/2026-05-27-glossarist-ruby-2.8.md
+++ b/blog/2026-05-27-glossarist-ruby-2.8.md
@@ -16,7 +16,7 @@ The V3 concept model introduces extended designation types, grouped concept file
 
 ## OWL ontology alignment
 
-The concept model now includes an OWL ontology that defines the class hierarchy, property definitions, and SHACL shapes for validation. This enables seamless integration with semantic web tooling and SPARQL endpoints.
+The concept model is now formally expressed as an OWL ontology with class hierarchy, property definitions, and SHACL shapes for validation. This enables seamless interoperability with semantic web tooling and SPARQL endpoints.
 
 ## SKOS taxonomy integration
 

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -1,11 +1,11 @@
 ---
 title: Concept Model
-description: The Glossarist concept system model — a rich, standards-aligned domain model for structured terminology management
+description: The Glossarist concept model — a self-contained, technology-neutral information model for structured terminology management
 ---
 
 # The Glossarist Concept Model
 
-A rich domain model for terminology management, aligned with ISO 10241-1, 704, 30042, 12620, and 25964 — designed to handle everything from simple glossaries to complex multilingual concept systems with formal ontological grounding.
+A self-contained information model for terminology management, aligned with ISO 10241-1, 704, 30042, 12620, and 25964 — designed to handle everything from simple glossaries to complex multilingual concept systems, with interoperability across multiple technology ecosystems.
 
 <ModelLanding />
 
@@ -67,8 +67,8 @@ Every entity in the Glossarist model maps to established international standards
 | **ISO 30042 / TBX** | Terminology markup framework — data exchange format |
 | **ISO 12620** | Data category registry — term type classifications |
 | **ISO 25964** | Thesauri — hierarchical and mapping relationships (BTG/NTG, BTP/NTP, BTI/NTI) |
-| **Semantic Web (OWL 2 / SHACL)** | Formal ontology vocabulary with shape constraints for data validation |
-| **SKOS / SKOS-XL** | Knowledge organization for the semantic web — concept schemes and reified labels |
+| **OWL 2 / SHACL** | Formal model definition — the concept model is expressed as an OWL ontology with SHACL shapes for validation and Semantic Web interoperability |
+| **SKOS / SKOS-XL** | Knowledge organization — concept schemes and reified labels for linked data mapping |
 
 ## Processing with code
 

--- a/docs/model/relationships.md
+++ b/docs/model/relationships.md
@@ -1,13 +1,13 @@
 ---
 title: Relationships
-description: Typed semantic relationship types between concepts, rendered from the Glossarist ontology
+description: Typed semantic relationship types between concepts, defined by the Glossarist concept model
 ---
 
 # Relationships
 
 Concepts in Glossarist are connected by **typed semantic relationships** — directional links that express how one concept relates to another. Every relationship has a type, a source concept, and a target concept.
 
-This page documents all relationship types organized by category, their ISO/SKOS alignment, and how to author them in YAML. The relationship definitions are rendered from the Glossarist ontology — the canonical source of truth.
+This page documents all relationship types organized by category, their ISO/SKOS alignment, and how to author them in YAML. The relationship definitions are derived from the Glossarist concept model.
 
 ## Overview
 

--- a/docs/model/schemas.md
+++ b/docs/model/schemas.md
@@ -1,6 +1,6 @@
 ---
 title: YAML Schema Reference
-description: V2 and V3 YAML schema definitions and enumeration values, rendered from the Glossarist ontology
+description: V2 and V3 YAML schema definitions and enumeration values defined by the Glossarist concept model
 ---
 
 # YAML Schema Reference
@@ -14,13 +14,13 @@ The YAML schemas for `concept` and `localized_concept` are available at the [con
 The concept model has two major schema versions:
 
 - **V2** — The original format, with concepts and localized concepts in separate directories (`concept/` and `localized_concept/`)
-- **V3** — The current format, supporting grouped concepts (all localizations in a single file), extended designation types, and ontology alignment
+- **V3** — The current format, supporting grouped concepts (all localizations in a single file), extended designation types, and a formally defined OWL ontology and SHACL shapes for validation
 
 Both formats are supported by `glossarist-ruby` for reading and writing.
 
 ## Entity Schemas and Enumerations
 
-The schemas below are rendered from the [Glossarist OWL ontology](/ontology) — the canonical source of truth. Every SHACL shape and SKOS ConceptScheme in the ontology is shown here.
+The schemas below reflect the Glossarist concept model's entity types and controlled vocabularies. The same definitions are available as an OWL ontology with SHACL shapes in the [Ontology Browser](/ontology).
 
 <YamlSchemas />
 


### PR DESCRIPTION
## Problem

The site positioned Glossarist as a Semantic Web tool — the OWL ontology was presented as the model itself ("rendered from the ontology — the canonical source of truth"). In reality, the Glossarist Concept Model is a self-contained, technology-neutral information model that interoperates with multiple ecosystems (Semantic Web, TBX, SKOS, JSON-LD).

## Changes (10 files)

| Area | Before | After |
|------|--------|-------|
| `YamlSchemas.vue` | "rendered from its SHACL shape definition" | "formally expressed as SHACL shapes for validation" |
| `YamlSchemas.vue` | "rendered from the SKOS ConceptSchemes in the ontology" | "also available as SKOS ConceptSchemes in the ontology" |
| `RelationshipTypes.vue` | "in the Glossarist ontology" | "in the Glossarist concept model" |
| `HomePage.vue` + `ModelLanding.vue` | "Ontology Classes" / "SHACL Shapes" | "Entity Types" / "Validation Shapes" |
| `HomePage.vue` | Card title: "Semantic Web & Linked Data" | "Formal Ontology" |
| `docs/model/index.md` | "formal ontological grounding" | "self-contained information model ... interoperability across multiple technology ecosystems" |
| `docs/model/index.md` standards | OWL/SHACL as defining standard | OWL/SHACL as formal model expression enabling interoperability |
| `docs/model/schemas.md` | "ontology alignment" | "formally defined OWL ontology and SHACL shapes for validation" |
| `docs/model/relationships.md` | "rendered from the Glossarist ontology — canonical source of truth" | "derived from the Glossarist concept model" |
| Blog posts | "includes an OWL ontology that defines" | "is now formally expressed as an OWL ontology" |

## Principle enforced

**The model stands on its own.** The OWL ontology, SHACL shapes, TBX, SKOS, JSON-LD are all interoperability targets — different expressions of the same model.