### PR TITLE
feat: add dynamic YAML schema browser

### DIFF
--- a/.vitepress/theme/components/SchemaReference.vue
+++ b/.vitepress/theme/components/SchemaReference.vue
@@ -1,0 +1,783 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+
+type JsonSchema = {
+  type?: string
+  description?: string
+  properties?: Record<string, JsonSchema>
+  items?: JsonSchema
+  required?: string[]
+  enum?: string[]
+  examples?: (string | number)[]
+  const?: string
+  $ref?: string
+  allOf?: JsonSchema[]
+  anyOf?: JsonSchema[]
+  additionalProperties?: boolean | JsonSchema
+  propertyNames?: JsonSchema
+  minLength?: number
+  maxLength?: number
+  format?: string
+  $defs?: Record<string, JsonSchema>
+  title?: string
+  [key: string]: unknown
+}
+
+type SchemaEntry = { file: string; title: string; description: string | null }
+type VersionIndex = { version: string; schemas: SchemaEntry[]; examples: string[] }
+
+const index = ref<VersionIndex[]>([])
+const activeVersion = ref('')
+const activeSchema = ref('')
+const schemaData = ref<JsonSchema | null>(null)
+const schemaRaw = ref('')
+const exampleRaw = ref('')
+const activeExample = ref('')
+const loading = ref(true)
+const viewMode = ref<'ref' | 'raw'>('ref')
+const expandedDefs = ref<Set<string>>(new Set())
+const sidebarOpen = ref(false)
+
+const versions = computed(() => index.value.map(v => v.version))
+const currentVersion = computed(() => index.value.find(v => v.version === activeVersion.value))
+const schemaEntries = computed(() => currentVersion.value?.schemas ?? [])
+
+onMounted(async () => {
+  const res = await fetch('/data/schemas/index.json')
+  index.value = await res.json()
+  if (index.value.length) {
+    activeVersion.value = index.value[0].version
+    if (index.value[0].schemas.length) {
+      await loadSchema(index.value[0].schemas[0].file)
+    }
+  }
+  loading.value = false
+})
+
+async function loadSchema(file: string) {
+  activeSchema.value = file
+  activeExample.value = ''
+  exampleRaw.value = ''
+  sidebarOpen.value = false
+  const res = await fetch(`/data/schemas/${activeVersion.value}/${file}`)
+  const raw = await res.text()
+  schemaRaw.value = raw
+  const YAML = await import('yaml')
+  schemaData.value = YAML.parse(raw) as JsonSchema
+  viewMode.value = 'ref'
+  expandedDefs.value = new Set()
+}
+
+async function loadExample(file: string) {
+  const res = await fetch(`/data/schemas/${activeVersion.value}/examples/${file}`)
+  exampleRaw.value = await res.text()
+  activeExample.value = file
+  sidebarOpen.value = false
+}
+
+function switchVersion(ver: string) {
+  activeVersion.value = ver
+  const vi = index.value.find(v => v.version === ver)
+  if (vi?.schemas.length) loadSchema(vi.schemas[0].file)
+}
+
+function backToSchema() {
+  activeExample.value = ''
+  exampleRaw.value = ''
+}
+
+function resolveRef(ref: string, root: JsonSchema): JsonSchema | null {
+  if (!ref.startsWith('#/$defs/')) return null
+  return root.$defs?.[ref.replace('#/$defs/', '')] ?? null
+}
+
+function resolveType(s: JsonSchema, root: JsonSchema): string {
+  if (s.$ref) {
+    const r = resolveRef(s.$ref, root)
+    return r ? resolveType(r, root) : (s.$ref.split('/').pop() ?? s.$ref)
+  }
+  if (s.enum) return 'enum'
+  if (s.allOf) return s.allOf.map(a => resolveType(a, root)).join(' & ')
+  if (s.anyOf) return s.anyOf.map(a => resolveType(a, root)).join(' | ')
+  if (s.type === 'array' && s.items) return `${resolveType(s.items, root)}[]`
+  if (s.type === 'object') return 'object'
+  return s.type ?? 'any'
+}
+
+function resolveEnum(s: JsonSchema, root: JsonSchema): string[] | null {
+  if (s.enum) return s.enum
+  if (s.$ref) { const r = resolveRef(s.$ref, root); if (r) return resolveEnum(r, root) }
+  if (s.allOf) { for (const sub of s.allOf) { const e = resolveEnum(sub, root); if (e) return e } }
+  return null
+}
+
+function topProps() {
+  if (!schemaData.value) return []
+  const root = schemaData.value
+  return Object.entries(root.properties ?? {}).map(([name, prop]) => ({ name, prop: prop as JsonSchema, root }))
+}
+
+function allDefs() {
+  if (!schemaData.value?.$defs) return []
+  return Object.entries(schemaData.value.$defs).map(([name, schema]) => ({ name, schema }))
+}
+
+function defProps(defSchema: JsonSchema) {
+  if (!schemaData.value || !defSchema.properties) return []
+  return Object.entries(defSchema.properties).map(([name, prop]) => ({ name, prop: prop as JsonSchema, root: schemaData.value! }))
+}
+
+function toggleDef(name: string) {
+  const next = new Set(expandedDefs.value)
+  next.has(name) ? next.delete(name) : next.add(name)
+  expandedDefs.value = next
+}
+
+function exampleGroups() {
+  const files = currentVersion.value?.examples ?? []
+  const groups: Record<string, string[]> = {}
+  for (const f of files) {
+    const prefix = f.split('-')[0]
+    ;(groups[prefix] ??= []).push(f)
+  }
+  return Object.entries(groups).map(([prefix, files]) => ({ prefix, files }))
+}
+</script>
+
+<template>
+  <div class="sb" v-if="!loading">
+    <!-- Top bar: version switcher + view toggle -->
+    <div class="sb-bar">
+      <div class="sb-bar-left">
+        <button class="sb-sidebar-toggle" @click="sidebarOpen = !sidebarOpen" :aria-label="sidebarOpen ? 'Close navigation' : 'Open navigation'">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+        </button>
+        <div class="sb-version-pills">
+          <button v-for="ver in versions" :key="ver" class="sb-pill" :class="{ active: activeVersion === ver }" @click="switchVersion(ver)">
+            {{ ver.toUpperCase() }}
+          </button>
+        </div>
+      </div>
+      <div v-if="!activeExample" class="sb-view-toggle">
+        <button class="sb-toggle-btn" :class="{ active: viewMode === 'ref' }" @click="viewMode = 'ref'">Reference</button>
+        <button class="sb-toggle-btn" :class="{ active: viewMode === 'raw' }" @click="viewMode = 'raw'">YAML</button>
+      </div>
+    </div>
+
+    <div class="sb-body">
+      <!-- Sidebar overlay for mobile -->
+      <div v-if="sidebarOpen" class="sb-overlay" @click="sidebarOpen = false"></div>
+
+      <!-- Sidebar -->
+      <aside class="sb-nav" :class="{ open: sidebarOpen }">
+        <div class="sb-nav-group">
+          <h4 class="sb-nav-heading">Schemas</h4>
+          <button v-for="s in schemaEntries" :key="s.file" class="sb-nav-link" :class="{ active: activeSchema === s.file && !activeExample }" @click="loadSchema(s.file)">
+            <span class="sb-nav-dot"></span>
+            {{ s.file.replace(/\.(yaml|yml)$/, '') }}
+          </button>
+        </div>
+        <div class="sb-nav-group">
+          <h4 class="sb-nav-heading">Examples</h4>
+          <div v-for="group in exampleGroups()" :key="group.prefix" class="sb-ex-group">
+            <span class="sb-ex-label">{{ group.prefix }}</span>
+            <button v-for="f in group.files" :key="f" class="sb-nav-link sb-nav-sub" :class="{ active: activeExample === f }" @click="loadExample(f)">
+              {{ f.replace(/^.+?-(.+)\.yaml$/, '$1') }}
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      <!-- Content -->
+      <main class="sb-content">
+        <!-- Example viewer -->
+        <div v-if="activeExample" class="sb-panel">
+          <div class="sb-panel-bar">
+            <button class="sb-back" @click="backToSchema">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+              Schema
+            </button>
+            <span class="sb-panel-title">{{ activeExample }}</span>
+          </div>
+          <div class="sb-code-wrap">
+            <pre class="sb-code"><code>{{ exampleRaw }}</code></pre>
+          </div>
+        </div>
+
+        <!-- Schema viewer -->
+        <template v-else-if="schemaData">
+          <!-- Raw YAML view -->
+          <div v-if="viewMode === 'raw'" class="sb-panel">
+            <div class="sb-panel-bar">
+              <span class="sb-panel-title">{{ schemaData.title || activeSchema }}</span>
+              <span class="sb-panel-badge">YAML</span>
+            </div>
+            <div class="sb-code-wrap">
+              <pre class="sb-code"><code>{{ schemaRaw }}</code></pre>
+            </div>
+          </div>
+
+          <!-- Reference view -->
+          <div v-else class="sb-panel">
+            <div class="sb-panel-header">
+              <div>
+                <h2 class="sb-title">{{ schemaData.title || activeSchema }}</h2>
+                <p v-if="schemaData.description" class="sb-subtitle">{{ schemaData.description }}</p>
+              </div>
+              <span class="sb-panel-badge">{{ activeVersion.toUpperCase() }}</span>
+            </div>
+
+            <!-- Top-level properties -->
+            <section class="sb-section">
+              <h3 class="sb-section-heading">Properties</h3>
+              <div class="sb-prop-list">
+                <div v-for="info in topProps()" :key="info.name" class="sb-prop">
+                  <div class="sb-prop-head">
+                    <code class="sb-prop-name">{{ info.name }}</code>
+                    <span class="sb-prop-type">{{ resolveType(info.prop, info.root) }}</span>
+                  </div>
+                  <p v-if="info.prop.description" class="sb-prop-desc">{{ info.prop.description }}</p>
+                  <div v-if="resolveEnum(info.prop, info.root)" class="sb-enum-row">
+                    <code v-for="v in resolveEnum(info.prop, info.root)" :key="v" class="sb-enum">{{ v }}</code>
+                  </div>
+                  <div v-else-if="info.prop.examples?.length" class="sb-enum-row">
+                    <span class="sb-example-label">e.g.</span>
+                    <code v-for="e in info.prop.examples" :key="String(e)" class="sb-example-val">{{ e }}</code>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <!-- Definitions -->
+            <section v-if="allDefs().length" class="sb-section">
+              <h3 class="sb-section-heading">Definitions <span class="sb-section-count">{{ allDefs().length }}</span></h3>
+              <div class="sb-def-list">
+                <div v-for="d in allDefs()" :key="d.name" class="sb-def">
+                  <button class="sb-def-head" @click="toggleDef(d.name)">
+                    <code class="sb-def-name">{{ d.name }}</code>
+                    <div class="sb-def-meta">
+                      <span v-if="d.schema.type" class="sb-def-type-tag">{{ d.schema.type }}</span>
+                      <span v-if="resolveEnum(d.schema, schemaData!)" class="sb-def-enum-tag">{{ resolveEnum(d.schema, schemaData!)!.length }} values</span>
+                    </div>
+                    <svg class="sb-def-chev" :class="{ open: expandedDefs.has(d.name) }" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+                  </button>
+                  <Transition name="sb-slide">
+                    <div v-if="expandedDefs.has(d.name)" class="sb-def-body">
+                      <p v-if="d.schema.description" class="sb-def-desc">{{ d.schema.description }}</p>
+                      <div v-if="resolveEnum(d.schema, schemaData!)" class="sb-enum-grid">
+                        <code v-for="v in resolveEnum(d.schema, schemaData!)" :key="v" class="sb-enum">{{ v }}</code>
+                      </div>
+                      <div v-else-if="d.schema.properties" class="sb-prop-list sb-prop-list-inner">
+                        <div v-for="p in defProps(d.schema)" :key="p.name" class="sb-prop">
+                          <div class="sb-prop-head">
+                            <code class="sb-prop-name">{{ p.name }}</code>
+                            <span class="sb-prop-type">{{ resolveType(p.prop, p.root) }}</span>
+                          </div>
+                          <p v-if="p.prop.description" class="sb-prop-desc">{{ p.prop.description }}</p>
+                          <div v-if="resolveEnum(p.prop, p.root)" class="sb-enum-row">
+                            <code v-for="v in resolveEnum(p.prop, p.root)" :key="v" class="sb-enum">{{ v }}</code>
+                          </div>
+                          <div v-else-if="p.prop.examples?.length" class="sb-enum-row">
+                            <span class="sb-example-label">e.g.</span>
+                            <code v-for="e in p.prop.examples" :key="String(e)" class="sb-example-val">{{ e }}</code>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </Transition>
+                </div>
+              </div>
+            </section>
+          </div>
+        </template>
+      </main>
+    </div>
+  </div>
+  <div v-else class="sb-loading">
+    <div class="sb-spinner"></div>
+    <span>Loading schemas&hellip;</span>
+  </div>
+</template>
+
+<style scoped>
+/* ─── Layout shell ─── */
+.sb { margin: 1.5rem 0; }
+
+.sb-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 3rem 0;
+  color: var(--vp-c-text-3);
+  font-style: italic;
+}
+
+.sb-spinner {
+  width: 18px; height: 18px;
+  border: 2px solid var(--vp-c-divider);
+  border-top-color: var(--g-teal);
+  border-radius: 50%;
+  animation: sb-spin 0.6s linear infinite;
+}
+
+@keyframes sb-spin { to { transform: rotate(360deg); } }
+
+/* ─── Top bar ─── */
+.sb-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+  margin-bottom: 1.25rem;
+}
+
+.sb-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sb-sidebar-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 32px; height: 32px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+  color: var(--vp-c-text-2);
+}
+
+.sb-version-pills {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.sb-pill {
+  padding: 0.3125rem 0.875rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 100px;
+  background: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--vp-c-text-3);
+  transition: all 0.15s;
+}
+
+.sb-pill:hover { color: var(--vp-c-text-1); border-color: var(--g-steel-mid); }
+.sb-pill.active { background: var(--g-navy); color: #fff; border-color: var(--g-navy); }
+
+/* View toggle */
+.sb-view-toggle {
+  display: flex;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.sb-toggle-btn {
+  padding: 0.3125rem 0.875rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--vp-c-text-3);
+  transition: all 0.15s;
+}
+
+.sb-toggle-btn + .sb-toggle-btn { border-left: 1px solid var(--vp-c-divider); }
+.sb-toggle-btn:hover { color: var(--vp-c-text-1); }
+.sb-toggle-btn.active { background: var(--vp-c-bg-soft); color: var(--vp-c-text-1); }
+
+/* ─── Body: sidebar + content ─── */
+.sb-body {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 1.5rem;
+}
+
+/* ─── Sidebar nav ─── */
+.sb-nav {
+  position: sticky;
+  top: 5.5rem;
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+  padding-right: 1rem;
+  scrollbar-width: thin;
+}
+
+.sb-nav-group { margin-bottom: 1.75rem; }
+
+.sb-nav-heading {
+  font-size: 0.625rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-3);
+  margin: 0 0 0.5rem;
+}
+
+.sb-nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.3125rem 0.5rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-2);
+  border-radius: 4px;
+  transition: all 0.12s;
+  font-family: var(--vp-font-family-mono);
+}
+
+.sb-nav-link:hover { background: var(--vp-c-bg-soft); color: var(--vp-c-text-1); }
+.sb-nav-link.active { background: rgba(63, 182, 176, 0.08); color: var(--g-teal); font-weight: 600; }
+
+.sb-nav-dot {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--vp-c-divider);
+  flex-shrink: 0;
+}
+
+.sb-nav-link.active .sb-nav-dot { background: var(--g-teal); }
+
+.sb-nav-sub {
+  font-size: 0.75rem;
+  font-family: var(--vp-font-family);
+  padding-left: 0.875rem;
+}
+
+.sb-ex-group { margin-bottom: 0.625rem; }
+
+.sb-ex-label {
+  display: block;
+  font-size: 0.625rem;
+  font-weight: 700;
+  color: var(--vp-c-text-3);
+  padding: 0.25rem 0 0.125rem 0.5rem;
+  letter-spacing: 0.03em;
+}
+
+/* ─── Main content ─── */
+.sb-content { min-width: 0; }
+
+.sb-panel {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.sb-panel-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-2);
+}
+
+.sb-panel-title {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.sb-panel-badge {
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--vp-c-default-soft);
+  padding: 0.125rem 0.5rem;
+  border-radius: 3px;
+  color: var(--vp-c-text-3);
+}
+
+.sb-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--g-teal);
+  font-weight: 500;
+}
+
+.sb-back:hover { color: var(--g-sea); }
+
+.sb-panel-header {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.sb-title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.sb-subtitle {
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-2);
+  margin: 0.25rem 0 0;
+  line-height: 1.5;
+}
+
+/* ─── Code blocks ─── */
+.sb-code-wrap {
+  overflow: auto;
+  max-height: 70vh;
+}
+
+.sb-code {
+  margin: 0;
+  padding: 1.25rem;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  white-space: pre;
+  tab-size: 2;
+}
+
+/* ─── Sections ─── */
+.sb-section {
+  padding: 1.25rem 1.5rem;
+}
+
+.sb-section + .sb-section {
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.sb-section-heading {
+  font-size: 0.6875rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vp-c-text-3);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sb-section-count {
+  font-size: 0.625rem;
+  background: var(--vp-c-default-soft);
+  padding: 0.0625rem 0.375rem;
+  border-radius: 3px;
+  font-weight: 700;
+}
+
+/* ─── Property rows ─── */
+.sb-prop-list { display: flex; flex-direction: column; gap: 0.625rem; }
+.sb-prop-list-inner { padding-left: 0; }
+
+.sb-prop {
+  padding: 0.625rem 0.75rem;
+  border-radius: 6px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+}
+
+.sb-prop-head {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.sb-prop-name {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.sb-prop-type {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.6875rem;
+  color: var(--g-teal);
+  background: rgba(63, 182, 176, 0.06);
+  padding: 0.0625rem 0.375rem;
+  border-radius: 3px;
+  letter-spacing: 0.01em;
+}
+
+.sb-prop-desc {
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-2);
+  line-height: 1.5;
+  margin: 0.375rem 0 0;
+}
+
+/* ─── Enums ─── */
+.sb-enum-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.375rem;
+}
+
+.sb-enum {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.6875rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 3px;
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+}
+
+.sb-example-label {
+  font-size: 0.6875rem;
+  color: var(--vp-c-text-3);
+  font-style: italic;
+}
+
+.sb-example-val {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.6875rem;
+  color: var(--vp-c-text-3);
+}
+
+.sb-enum-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin: 0.5rem 0;
+}
+
+/* ─── Definitions ─── */
+.sb-def-list { display: flex; flex-direction: column; gap: 0.25rem; }
+
+.sb-def {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--vp-c-bg);
+}
+
+.sb-def-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.sb-def-head:hover { background: var(--vp-c-bg-soft); }
+
+.sb-def-name {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.sb-def-meta {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.sb-def-type-tag {
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--vp-c-text-3);
+}
+
+.sb-def-enum-tag {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--g-teal);
+  background: rgba(63, 182, 176, 0.08);
+  padding: 0.0625rem 0.375rem;
+  border-radius: 3px;
+}
+
+.sb-def-chev {
+  margin-left: auto;
+  color: var(--vp-c-text-3);
+  transition: transform 0.15s;
+}
+
+.sb-def-chev.open { transform: rotate(90deg); }
+
+.sb-def-body {
+  padding: 0.75rem 1rem 1rem;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.sb-def-desc {
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-2);
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+/* Slide transition */
+.sb-slide-enter-active,
+.sb-slide-leave-active {
+  transition: all 0.15s ease;
+  overflow: hidden;
+}
+
+.sb-slide-enter-from,
+.sb-slide-leave-to {
+  opacity: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 768px) {
+  .sb-body { grid-template-columns: 1fr; }
+
+  .sb-sidebar-toggle { display: flex; }
+
+  .sb-nav {
+    display: none;
+    position: fixed;
+    top: 0; left: 0; bottom: 0;
+    width: 280px;
+    z-index: 50;
+    background: var(--vp-c-bg);
+    border-right: 1px solid var(--vp-c-divider);
+    padding: 1.5rem 1rem;
+    max-height: 100vh;
+  }
+
+  .sb-nav.open { display: block; }
+
+  .sb-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 49;
+    background: rgba(0, 0, 0, 0.4);
+  }
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import ReleaseDownloader from './components/ReleaseDownloader.vue'
 import OntologyBrowser from './components/OntologyBrowser.vue'
 import RelationshipTypes from './components/RelationshipTypes.vue'
 import YamlSchemas from './components/YamlSchemas.vue'
+import SchemaReference from './components/SchemaReference.vue'
 import ModelLanding from './components/ModelLanding.vue'
 import LogoMerge from './components/LogoMerge.vue'
 
@@ -20,6 +21,7 @@ export default {
     app.component('OntologyBrowser', OntologyBrowser)
     app.component('RelationshipTypes', RelationshipTypes)
     app.component('YamlSchemas', YamlSchemas)
+    app.component('SchemaReference', SchemaReference)
     app.component('ModelLanding', ModelLanding)
     app.component('LogoMerge', LogoMerge)
   }

--- a/docs/model/schemas.md
+++ b/docs/model/schemas.md
@@ -1,32 +1,50 @@
 ---
 title: YAML Schema Reference
-description: V2 and V3 YAML schema definitions and enumeration values defined by the Glossarist concept model
+description: JSON Schema definitions for Glossarist concept data — V2 and V3 YAML format, field reference, enum values, and examples
 ---
 
 # YAML Schema Reference
 
-Glossarist concept data is stored as YAML files following the [Glossarist concept model](https://github.com/glossarist/concept-model/tree/main).
-
-The YAML schemas for `concept` and `localized_concept` are available at the [concept-model repository](https://github.com/glossarist/concept-model/tree/main/yaml_schemas).
-
-## V2 and V3 schema
+Glossarist concept data is stored as YAML files validated against [JSON Schema](https://json-schema.org/) definitions. The canonical schemas live in the [concept-model repository](https://github.com/glossarist/concept-model/tree/main/schemas).
 
 The concept model has two major schema versions:
 
-- **V2** — The original format, with concepts and localized concepts in separate directories (`concept/` and `localized_concept/`)
-- **V3** — The current format, supporting grouped concepts (all localizations in a single file), extended designation types, and a formally defined OWL ontology and SHACL shapes for validation
+- **V2** — Original format, with concepts and localized concepts in separate directories
+- **V3** — Current format, with all localizations in a single file per concept, extended designation types, and a formally defined OWL ontology with SHACL shapes for validation
 
-Both formats are supported by `glossarist-ruby` for reading and writing.
+Both formats are supported by [glossarist-ruby](/docs/software/glossarist-ruby) and [glossarist-js](/docs/software/glossarist-js) for reading and writing.
 
-## Entity Schemas and Enumerations
+## JSON Schema
 
-The schemas below reflect the Glossarist concept model's entity types and controlled vocabularies. The same definitions are available as an OWL ontology with SHACL shapes in the [Ontology Browser](/ontology).
+<SchemaReference />
+
+## Examples
+
+Each schema feature is demonstrated with standalone YAML examples in the concept-model repository:
+
+| # | Topic | What it shows |
+|---|-------|---------------|
+| 01 | Minimal concept | Smallest valid concept + localization |
+| 02 | Designations | All 7 designation types, grammar info, term types |
+| 03 | Pronunciation | IPA, Hepburn romanization, script cascade |
+| 04 | Definition, notes, examples | DetailedDefinition with per-item sources |
+| 05 | Domains | Classification and subject area references |
+| 06 | Relationships | All 32 typed semantic relationship types |
+| 07 | Sources & citations | All 10 source statuses, locality, custom locality |
+| 08 | Multi-language | Four scripts (Latn, Arab, Hani, Cyrl) in one concept |
+| 09 | Non-verbal representations | Images, tables, formulas |
+| 10 | Concept references | Local, URN, and designation references |
+| 11 | Lifecycle & review | Status transitions, review metadata, release version |
+| 12 | Absent designations | Explicitly missing designations, international symbols |
+| 13 | Superseded & deprecated | Full deprecation lifecycle |
+| 14 | Term types | All 34 ISO 12620 term type values |
+| 15 | Citation features | Locality ranges, custom locality, links |
+
+- [V3 examples (GitHub)](https://github.com/glossarist/concept-model/tree/main/schemas/v3/examples)
+- [V2 examples (GitHub)](https://github.com/glossarist/concept-model/tree/main/schemas/v2/examples)
+
+## Ontology Entity View
+
+The tables below show each entity type's fields and all controlled vocabularies, derived from the concept model's OWL ontology.
 
 <YamlSchemas />
-
-## Links
-
-- [Concept model repository](https://github.com/glossarist/concept-model)
-- [YAML schemas](https://github.com/glossarist/concept-model/tree/main/yaml_schemas)
-- [OWL ontology](https://github.com/glossarist/concept-model/tree/main/ontologies)
-- [Ontology Browser](/ontology) — Interactive browser for the full ontology

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "glossarist.org",
       "version": "1.0.0",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      },
       "devDependencies": {
         "typescript": "^5.7.3",
         "vitepress": "^1.6.4",
@@ -2527,6 +2530,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "npm run build:data && vitepress build",
-    "build:data": "node scripts/generate-ontology-data.mjs && node scripts/generate-ontology-schema.mjs",
+    "build:data": "node scripts/generate-ontology-data.mjs && node scripts/generate-ontology-schema.mjs && node scripts/copy-schemas.mjs",
     "preview": "vitepress preview"
   },
   "devDependencies": {
     "typescript": "^5.7.3",
     "vitepress": "^1.6.4",
     "vue": "^3.5.13"
+  },
+  "dependencies": {
+    "yaml": "^2.9.0"
   }
 }

--- a/scripts/copy-schemas.mjs
+++ b/scripts/copy-schemas.mjs
@@ -1,0 +1,52 @@
+import { cpSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+
+const root = resolve(import.meta.dirname, '..')
+const src = resolve(root, '..', 'concept-model', 'schemas')
+const dest = resolve(root, 'public', 'data', 'schemas')
+
+if (!existsSync(src)) {
+  console.error('concept-model schemas not found at', src)
+  console.error('Clone https://github.com/glossarist/concept-model to ../concept-model/')
+  process.exit(1)
+}
+
+mkdirSync(dest, { recursive: true })
+cpSync(src, dest, { recursive: true })
+
+// Build index: discover versions and schema files dynamically
+const versions = readdirSync(dest, { withFileTypes: true })
+  .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'examples')
+  .map(d => d.name)
+  .sort()
+  .reverse() // newest first
+
+const index = versions.map(ver => {
+  const verDir = join(dest, ver)
+  const schemas = readdirSync(verDir, { withFileTypes: true })
+    .filter(f => f.isFile() && (f.name.endsWith('.yaml') || f.name.endsWith('.yml')))
+    .map(f => {
+      // Extract title from schema file
+      const content = readFileSync(join(verDir, f.name), 'utf-8')
+      const titleMatch = content.match(/^title:\s*['"]?(.+?)['"]?\s*$/m)
+      const descMatch = content.match(/^description:\s*\|?\s*(.+?)\s*$/m)
+      return {
+        file: f.name,
+        title: titleMatch?.[1] || f.name.replace(/\.(yaml|yml)$/, ''),
+        description: descMatch?.[1] || null,
+      }
+    })
+
+  // Discover examples
+  const exDir = join(verDir, 'examples')
+  const examples = existsSync(exDir)
+    ? readdirSync(exDir)
+        .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))
+        .sort()
+    : []
+
+  return { version: ver, schemas, examples }
+})
+
+writeFileSync(join(dest, 'index.json'), JSON.stringify(index, null, 2))
+console.log(`Schema index: ${versions.join(', ')} — ${index.reduce((sum, v) => sum + v.schemas.length, 0)} schemas, ${index.reduce((sum, v) => sum + v.examples.length, 0)} examples`)


### PR DESCRIPTION
Adds a proper JSON Schema / YAML schema browser to the /docs/model/schemas page.

**What it does:**
- Dynamically discovers schemas from the concept-model repo via build-time pipeline
- Renders properties, types, enums, examples, and definitions in a reference view
- Toggle between Reference view and raw YAML
- Browse schema examples grouped by topic
- Version switcher (V2/V3) with pill selector
- Sticky sidebar navigation, mobile-responsive with drawer

**Files:**
- `SchemaReference.vue` — Full schema browser component (Vue 3 SFC)
- `scripts/copy-schemas.mjs` — Copies schemas from concept-model repo and generates index
- `docs/model/schemas.md` — Rewritten to lead with JSON Schema, ontology view demoted
- `package.json` — Added yaml dependency and copy-schemas to build pipeline