### PR TITLE
feat: restructure information architecture

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   lang: 'en-US',
   lastUpdated: true,
 
-  srcExclude: ['TODO.website/**', 'concept-model/**', 'CLAUDE.md', 'README.md', 'LICENSE', 'scripts/**'],
+  srcExclude: ['TODO.website/**', 'TODO.refactor/**', 'TODO.cleanup/**', 'TODO.infoarch/**', 'concept-model/**', 'CLAUDE.md', 'README.md', 'LICENSE', 'scripts/**'],
 
   sitemap: {
     hostname: 'https://www.glossarist.org'
@@ -32,8 +32,10 @@ export default defineConfig({
           { text: 'Designations', link: '/docs/model/designations' },
           { text: 'Relationships', link: '/docs/model/relationships' },
           { text: 'Sources', link: '/docs/model/sources' },
-          { text: 'Schemas', link: '/docs/model/schemas' },
-          { text: 'Ontology Browser', link: '/ontology' },
+          { text: 'Term Types', link: '/docs/model/term-types' },
+          { text: 'YAML Schema Reference', link: '/docs/model/schemas/yaml-reference' },
+          { text: 'Entity Field Reference', link: '/docs/model/schemas/entity-fields' },
+          { text: 'Ontology Browser', link: '/docs/model/ontology' },
         ]
       },
       { text: 'Software', items: softwareNavItems },
@@ -104,7 +106,15 @@ export default defineConfig({
             { text: 'Relationships', link: '/docs/model/relationships' },
             { text: 'Sources', link: '/docs/model/sources' },
             { text: 'Term Types', link: '/docs/model/term-types' },
-            { text: 'Schemas', link: '/docs/model/schemas' },
+          ]
+        },
+        {
+          text: 'Schema Reference',
+          items: [
+            { text: 'YAML Schemas', link: '/docs/model/schemas/' },
+            { text: 'YAML Schema Browser', link: '/docs/model/schemas/yaml-reference' },
+            { text: 'Entity Field Reference', link: '/docs/model/schemas/entity-fields' },
+            { text: 'Ontology Browser', link: '/docs/model/ontology' },
           ]
         },
       ],

--- a/.vitepress/theme/components/ModelLanding.vue
+++ b/.vitepress/theme/components/ModelLanding.vue
@@ -23,7 +23,7 @@ const entities = [
   { href: '/docs/model/designations', dotColor: 'var(--g-teal)', title: 'Designations', desc: 'Designation types in a MECE hierarchy — expressions, abbreviations, symbols (letter and graphical), prefixes, and suffixes.', fields: ['expression', 'abbreviation', 'symbol', 'letter_symbol', 'graphical_symbol', 'prefix', 'suffix'] },
   { href: '/docs/model/relationships', dotColor: 'var(--g-shape)', title: 'Relationships', desc: 'Typed semantic links spanning 4 ISO standards — hierarchical, partitive, associative, equivalence, mapping, and spatiotemporal.', fields: ['broader/narrower', 'generic/partitive', 'exact_match', 'deprecates', 'and more'] },
   { href: '/docs/model/sources', dotColor: 'var(--g-taxonomy)', title: 'Sources', desc: 'Multi-level provenance tracking — authoritative and lineage sources with status tracking (identical, modified, restyled, generalisation).', fields: ['authoritative', 'lineage', 'status', 'origin', 'modification'] },
-  { href: '/ontology', dotColor: 'linear-gradient(135deg, var(--g-steel), var(--g-teal))', title: 'Formal Ontology', desc: 'The concept model is formally expressed as an OWL ontology with SHACL validation shapes. Interoperates with SKOS, SKOS-XL, ISO 25964, PROV-O, and Dublin Core for linked data integration.', fields: ['owl:Class', 'sh:Shape', 'skos:Concept', 'skosxl:Label'] },
+  { href: '/docs/model/ontology', dotColor: 'linear-gradient(135deg, var(--g-steel), var(--g-teal))', title: 'Formal Ontology', desc: 'The concept model is formally expressed as an OWL ontology with SHACL validation shapes. Interoperates with SKOS, SKOS-XL, ISO 25964, PROV-O, and Dublin Core for linked data integration.', fields: ['owl:Class', 'sh:Shape', 'skos:Concept', 'skosxl:Label'] },
 ]
 </script>
 

--- a/TODO.infoarch/0-audit-summary.md
+++ b/TODO.infoarch/0-audit-summary.md
@@ -1,0 +1,61 @@
+# Information Architecture Audit
+
+## Current State
+
+The site has 5 top-level nav items, 4 sidebar sections, and ~70 content pages. The content is mostly sound, but the architecture has structural problems that make the site confusing to navigate and hard to extend.
+
+## Critical Issues
+
+1. **The `/docs/model/schemas` page is an incoherent dumping ground** — it crams a JSON Schema browser, an examples table, and an ontology entity view into one page with no clear hierarchy. See [1-schemas-page-split.md](1-schemas-page-split.md).
+
+2. **The ontology browser is an orphan outside the docs tree** — `/ontology` lives at the site root with its own `layout: page`, no sidebar, and no breadcrumbs. It's linked from the nav dropdown but invisible to the docs sidebar and in-page navigation. See [2-ontology-placement.md](2-ontology-placement.md).
+
+3. **The model section has no schema/entity reference pages** — the model docs describe concepts, designations, relationships, etc. in prose, but there's no structured reference page per entity type. The YamlSchemas component (showing all entities in one big table) is buried at the bottom of the schemas page. See [3-model-reference-structure.md](3-model-reference-structure.md).
+
+4. **`docs/index.md` is a flat link dump** — the docs landing page is a list of links with no narrative, no visual hierarchy, and no guidance on where to start. See [4-docs-landing-page.md](4-docs-landing-page.md).
+
+5. **About page has a duplicated "Get Started" step** — step 3 and 4 are identical ("Explore the Model"). See [5-about-page-fixes.md](5-about-page-fixes.md).
+
+6. **Nav dropdown "Model" mixes conceptual pages with tools** — it lists Overview, Concepts, Designations, Relationships, Sources, Schemas (conceptual docs) alongside Ontology Browser (an interactive tool). Different user intents, same dropdown. See [6-nav-restructure.md](6-nav-restructure.md).
+
+7. **The schema browser is entirely client-rendered** — `<SchemaReference />` fetches YAML at runtime, so the content is invisible to search engines, shows a loading spinner on every visit, and adds unnecessary latency for what should be static documentation. See [1-schemas-page-split.md](1-schemas-page-split.md).
+
+8. **No cross-links between model docs and schema reference** — `concepts.md` describes ManagedConcept fields but doesn't link to the JSON Schema definition. `designations.md` explains the hierarchy but doesn't link to the schema. The model docs and schema reference are parallel universes. See [7-cross-linking.md](7-cross-linking.md).
+
+## Architecture Diagram
+
+```
+glossarist.org/
+├── index.md                          ← HomePage component (OK)
+├── about.md                          ← About (needs fix: dup step)
+├── ontology.md                       ← Orphaned ontology browser (needs placement)
+├── blog/                             ← Blog (OK)
+├── docs/
+│   ├── index.md                      ← Flat link dump (needs redesign)
+│   ├── standards.md                  ← Standards compliance (OK)
+│   ├── model/
+│   │   ├── index.md                  ← ModelLanding + overview (OK)
+│   │   ├── concepts.md               ← Prose description (needs schema links)
+│   │   ├── designations.md           ← Prose + table (needs schema links)
+│   │   ├── relationships.md          ← RelationshipTypes component (needs content)
+│   │   ├── sources.md                ← Prose + table (OK)
+│   │   ├── term-types.md             ← Prose + table (OK)
+│   │   ├── schemas.md                ← DUMPSTER FIRE (needs split)
+│   │   └── ontology.md               ← Redirect to /ontology (dangling)
+│   ├── core-concepts/                ← Background theory (OK)
+│   ├── desktop/                      ← Desktop app docs (OK)
+│   ├── software/                     ← Software product pages (OK)
+│   └── adopt/                        ← Adoption guide (OK)
+```
+
+## Recommended Changes (Priority Order)
+
+| # | TODO | Impact | Effort |
+|---|------|--------|--------|
+| 1 | Split schemas.md into dedicated pages | High | Medium |
+| 2 | Move ontology into docs tree | High | Low |
+| 3 | Add per-entity reference pages under model | Medium | Medium |
+| 4 | Redesign docs landing page | Medium | Low |
+| 5 | Fix about page duplicate | Low | Trivial |
+| 6 | Restructure nav dropdown | Medium | Low |
+| 7 | Add cross-links between model and schema docs | Medium | Low |

--- a/TODO.infoarch/1-schemas-page-split.md
+++ b/TODO.infoarch/1-schemas-page-split.md
@@ -1,0 +1,96 @@
+# 1. Split schemas.md into Dedicated Pages
+
+## Problem
+
+`/docs/model/schemas` is a single page that tries to be three things:
+1. An intro explaining JSON Schema and V2/V3 differences
+2. A schema browser (`<SchemaReference />`) — a full-page component crammed into a markdown section
+3. An ontology entity view (`<YamlSchemas />`) — another full-page component buried at the bottom
+
+The result: neither component gets the space or context it needs. The schema browser has 14 collapsed definitions, a sidebar, version switching — all fighting for screen space alongside prose and tables. The ontology view is hidden below the fold with no way to discover it.
+
+Additionally, `<SchemaReference />` is entirely client-rendered: it fetches YAML files at runtime, shows a loading spinner, and is invisible to search engines. For static documentation, this is wrong.
+
+## Proposed Structure
+
+Replace the single `schemas.md` with a `schemas/` directory:
+
+```
+docs/model/schemas/
+├── index.md              ← Intro page: what schemas are, V2/V3 overview, links to sub-pages
+├── yaml-reference.md     ← The schema browser (dedicated full page)
+└── entity-fields.md      ← The YamlSchemas entity view (dedicated full page)
+```
+
+### `schemas/index.md`
+- Intro text about JSON Schema, V2/V3 differences, links to glossarist-ruby and glossarist-js
+- Card grid linking to YAML Reference and Entity Fields
+- Examples table (moved here from current schemas.md)
+- Links to GitHub example directories
+
+### `schemas/yaml-reference.md`
+- Full-page schema browser component
+- Change `<SchemaReference />` to pre-render at build time instead of client-fetching:
+  - `copy-schemas.mjs` already copies schemas to `public/data/schemas/`
+  - Add a new build script that generates a JSON representation of all schemas (properties, types, enums, definitions) into `public/data/schemas/processed.json`
+  - Or better: generate a VitePress data loader that makes the schema available at build time
+  - The component should hydrate from pre-rendered HTML, not fetch on mount
+- Remove the examples sidebar from this component (examples live on index.md)
+
+### `schemas/entity-fields.md`
+- `<YamlSchemas />` gets its own page with proper heading and context
+- Or better: inline the entity field reference as pre-rendered tables
+
+## Sidebar Update
+
+```ts
+'/docs/model/': [
+  {
+    text: 'Concept Model',
+    items: [
+      { text: 'Overview', link: '/docs/model/' },
+      { text: 'Concepts', link: '/docs/model/concepts' },
+      { text: 'Designations', link: '/docs/model/designations' },
+      { text: 'Relationships', link: '/docs/model/relationships' },
+      { text: 'Sources', link: '/docs/model/sources' },
+      { text: 'Term Types', link: '/docs/model/term-types' },
+      // Replace single "Schemas" with group
+      { text: 'YAML Schema Reference', link: '/docs/model/schemas/' },
+      { text: 'Entity Field Reference', link: '/docs/model/schemas/entity-fields' },
+    ]
+  },
+]
+```
+
+## Build-Time Pre-Rendering (Critical)
+
+The current `<SchemaReference />` fetches YAML at runtime. This needs to change:
+
+**Option A: Build-time data generation**
+- Extend `copy-schemas.mjs` to generate a `processed.json` with all schema properties, types, enums, and definitions pre-extracted
+- The component loads from this JSON (smaller payload, no YAML parsing needed)
+- Still client-rendered but faster
+
+**Option B: VitePress data loader**
+- Use VitePress's `createLoader` or a custom plugin to inject schema data at build time
+- The component renders server-side during VitePress build
+- Full SEO, no spinner, instant load
+- This is the correct approach
+
+**Option C: Static markdown generation**
+- Build script generates `.md` files from schemas at build time
+- Pure static HTML, no component needed
+- Most SEO-friendly but loses interactivity (version switcher, collapsible defs)
+
+Recommendation: **Option B**. Pre-render the schema data at build time using VitePress's data loading, then hydrate the component for interactivity.
+
+## Files to Modify
+
+- Delete `docs/model/schemas.md`
+- Create `docs/model/schemas/index.md`
+- Create `docs/model/schemas/yaml-reference.md`
+- Create `docs/model/schemas/entity-fields.md`
+- Update `.vitepress/config.ts` sidebar
+- Update `.vitepress/config.ts` nav dropdown
+- Possibly modify `SchemaReference.vue` for SSR compatibility
+- Possibly add build-time schema processing script

--- a/TODO.infoarch/2-ontology-placement.md
+++ b/TODO.infoarch/2-ontology-placement.md
@@ -1,0 +1,67 @@
+# 2. Move Ontology Browser into the Docs Tree
+
+## Problem
+
+The ontology browser lives at `/ontology` — a standalone page at the site root with:
+- Its own `layout: page` (full-width, no sidebar)
+- No breadcrumbs
+- No relation to the docs sidebar
+- No link from any docs page except the nav dropdown and `docs/model/ontology.md` (which is just a JS redirect)
+
+The `docs/model/ontology.md` file is a redirect stub that does `window.location.replace('/ontology')`. This is a hack — it means `/docs/model/ontology` (which is in the docs tree) redirects to a completely separate layout outside the docs.
+
+## Why This Is Wrong
+
+1. The ontology browser documents the concept model — it belongs in `/docs/model/`
+2. Users browsing the model sidebar never see it
+3. It has no sidebar context, so users can't navigate to related model pages
+4. The redirect stub in `docs/model/ontology.md` is dead weight — VitePress builds it just to redirect
+5. Search engines index `/ontology.html` as a standalone page with no surrounding navigation context
+
+## Proposed Fix
+
+Move the ontology browser to `/docs/model/ontology.md`:
+
+```
+docs/model/ontology.md   ← Actual content (not a redirect)
+```
+
+### Changes to make:
+
+1. **Replace `docs/model/ontology.md`** — remove the redirect stub, put `<OntologyBrowser />` here instead
+2. **Remove `ontology.md` from the site root** — it's no longer needed
+3. **Update the nav dropdown** — change `/ontology` to `/docs/model/ontology`
+4. **Update the sidebar** — add "Ontology Browser" to the model sidebar
+5. **Update `layout: page`** — the OntologyBrowser component needs the full-width `layout: page` frontmatter, which works fine within `/docs/model/`
+6. **Update `docs/model/index.md`** — the "Reference sections" list already links to `/docs/model/ontology`, just make sure it points to the new location
+
+### Sidebar:
+
+```ts
+'/docs/model/': [
+  {
+    text: 'Concept Model',
+    items: [
+      { text: 'Overview', link: '/docs/model/' },
+      { text: 'Concepts', link: '/docs/model/concepts' },
+      { text: 'Designations', link: '/docs/model/designations' },
+      { text: 'Relationships', link: '/docs/model/relationships' },
+      { text: 'Sources', link: '/docs/model/sources' },
+      { text: 'Term Types', link: '/docs/model/term-types' },
+      { text: 'YAML Schema Reference', link: '/docs/model/schemas/' },
+      { text: 'Entity Field Reference', link: '/docs/model/schemas/entity-fields' },
+      { text: 'Ontology Browser', link: '/docs/model/ontology' },
+    ]
+  },
+]
+```
+
+### Cleanup:
+- Delete root-level `ontology.md`
+- Remove redirect JavaScript from `docs/model/ontology.md`
+
+## Files to Modify
+
+- `docs/model/ontology.md` — Replace redirect with actual OntologyBrowser component
+- `ontology.md` — Delete
+- `.vitepress/config.ts` — Update nav link and sidebar

--- a/TODO.infoarch/3-model-reference-structure.md
+++ b/TODO.infoarch/3-model-reference-structure.md
@@ -1,0 +1,65 @@
+# 3. Add Per-Entity Reference Pages Under Model
+
+## Problem
+
+The model section has prose documentation pages (concepts.md, designations.md, etc.) that explain each entity in paragraph form with inline tables. But there's no structured, authoritative field reference per entity type.
+
+The `<YamlSchemas />` component (ontology entity view) shows all 24 entity types in one massive table, but it's buried at the bottom of the schemas page. Individual entity pages don't exist.
+
+Compare to how API documentation works: you have a concept overview page AND a dedicated reference page per endpoint/entity. Glossarist's model docs have only the overview.
+
+## Current State
+
+- `concepts.md` — Lists ManagedConcept and LocalizedConcept fields in markdown tables (63 lines)
+- `designations.md` — Lists designation types and base properties in tables (52 lines)
+- `sources.md` — Lists source types and statuses (53 lines)
+- `term-types.md` — Lists ISO 12620 term types (57 lines)
+- `relationships.md` — Uses `<RelationshipTypes />` component (132 lines)
+
+These pages describe entities but don't show the authoritative field list with types, constraints, cardinality, and examples. The YamlSchemas component does that — but it's all in one undifferentiated page.
+
+## Proposed Structure
+
+Option A: Add a "Reference" sub-section under model
+
+```
+docs/model/
+├── index.md
+├── concepts.md          ← Conceptual overview (keep as-is)
+├── designations.md      ← Conceptual overview (keep as-is)
+├── relationships.md
+├── sources.md
+├── term-types.md
+├── schemas/             ← Schema reference section (from TODO 1)
+└── reference/           ← Entity field reference section
+    ├── managed-concept.md
+    ├── localized-concept.md
+    ├── designation.md
+    ├── concept-source.md
+    ├── detailed-definition.md
+    └── ...
+```
+
+Option B: Enhance existing pages with a "Field Reference" section
+
+Each conceptual page gets a second half with the authoritative field table:
+
+```markdown
+## ManagedConcept Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| id | string | yes | Management identifier |
+| ... | ... | ... | ... |
+```
+
+**Recommendation: Option B**. It's lower effort, avoids duplicating pages, and keeps conceptual + reference content together. The per-entity field tables from YamlSchemas should be inlined into the relevant model page.
+
+The `<YamlSchemas />` component can then be removed — its content is better served as static tables on the relevant pages.
+
+## Files to Modify
+
+- `docs/model/concepts.md` — Add field reference tables from YamlSchemas
+- `docs/model/designations.md` — Add field reference for Designation and sub-types
+- `docs/model/sources.md` — Add field reference for ConceptSource
+- Potentially remove `YamlSchemas.vue` once content is inlined

--- a/TODO.infoarch/4-docs-landing-page.md
+++ b/TODO.infoarch/4-docs-landing-page.md
@@ -1,0 +1,71 @@
+# 4. Redesign Docs Landing Page
+
+## Problem
+
+`/docs/index.md` is a flat list of links with no visual hierarchy, no narrative, and no guidance:
+
+```markdown
+# Documentation
+
+Welcome to Glossarist documentation. Choose a section below to get started.
+
+## Desktop Application
+- [Getting Started](/docs/desktop/)
+- [Installation](/docs/desktop/getting-started/installation)
+...
+
+## Concept Model
+- [Model Overview](/docs/model/)
+...
+
+## Core Concepts
+...
+
+## Adopting Glossarist
+...
+
+## Software
+...
+
+## Standards
+...
+```
+
+This is a sitemap, not a landing page. A new visitor doesn't know which section to visit first, what the relationship between sections is, or what Glossarist even does.
+
+## Proposed Redesign
+
+A docs landing page should answer three questions instantly:
+1. **What is this?** (one-line description)
+2. **Where do I start?** (guided paths for different user types)
+3. **Where is everything?** (organized navigation)
+
+### Structure:
+
+```markdown
+# Documentation
+
+Glossarist provides open-source tools for maintaining multi-language concept systems, aligned with ISO standards.
+
+## Get Started
+
+Choose your path:
+
+| I want to... | Go to |
+|-------------|-------|
+| Understand the concept model | [Concept Model Overview →](/docs/model/) |
+| Install the desktop app | [Installation Guide →](/docs/desktop/getting-started/installation) |
+| Adopt Glossarist in my organization | [Adoption Guide →](/docs/adopt/) |
+| Browse the code | [Software Ecosystem →](/docs/software/) |
+| Understand the theory | [Core Concepts →](/docs/core-concepts/) |
+```
+
+### Visual treatment:
+- Use a card grid or table, not a flat link list
+- Each card has: title, 1-line description, link
+- Guided paths at the top ("I want to..."), reference navigation below
+- Maybe a `<DocsLanding />` Vue component for visual polish
+
+## Files to Modify
+
+- `docs/index.md` — Complete rewrite

--- a/TODO.infoarch/5-about-page-fixes.md
+++ b/TODO.infoarch/5-about-page-fixes.md
@@ -1,0 +1,42 @@
+# 5. Fix About Page
+
+## Problem 1: Duplicate "Get Started" Step
+
+The about page has two identical steps:
+
+```markdown
+## Get Started
+
+1. **Adopt Glossarist** — Read the [Adoption Guide](/docs/adopt/)
+2. **Try the Desktop App** — [Download](/docs/software/desktop) and get started
+3. **Explore the Model** — Read the [Concept Model docs](/docs/model/)
+4. **Explore the Model** — Read the [Concept Model docs](/docs/model/)    ← DUPLICATE
+5. **Browse the Ontology** — Explore the [interactive OWL ontology browser](/ontology)
+6. **View on GitHub** — Browse the [source code](https://github.com/glossarist)
+```
+
+Step 3 and 4 are identical.
+
+## Fix
+
+Remove the duplicate. The correct sequence should be:
+
+```markdown
+## Get Started
+
+1. **Explore the Concept Model** — Read the [Concept Model docs](/docs/model/)
+2. **Try the Desktop App** — [Download](/docs/software/desktop) and get started
+3. **Adopt Glossarist** — Read the [Adoption Guide](/docs/adopt/)
+4. **Browse the Ontology** — Explore the [OWL ontology browser](/docs/model/ontology)
+5. **View on GitHub** — Browse the [source code](https://github.com/glossarist)
+```
+
+Note: re-ordered to put "explore the model" first (lowest commitment), and updated ontology link to reflect proposed move from TODO 2.
+
+## Problem 2: No link to schema reference
+
+The about page doesn't mention the YAML Schema Reference at all. Given that the schema browser is a key documentation asset, it should be in the Get Started list.
+
+## Files to Modify
+
+- `about.md` — Remove duplicate step, reorder, update links

--- a/TODO.infoarch/6-nav-restructure.md
+++ b/TODO.infoarch/6-nav-restructure.md
@@ -1,0 +1,56 @@
+# 6. Restructure Nav Dropdown
+
+## Problem
+
+The "Model" nav dropdown mixes two different user intents:
+
+**Conceptual understanding** (documentation pages):
+- Overview, Concepts, Designations, Relationships, Sources, Schemas
+
+**Interactive tool** (web app):
+- Ontology Browser
+
+The Ontology Browser is an interactive tool that happens to document the model — it's not a documentation page. Putting it alongside "Concepts" and "Sources" conflates reading docs with using a tool.
+
+Additionally, the dropdown doesn't include Term Types (which is in the sidebar but not the nav).
+
+## Current Nav
+
+```
+Model dropdown:
+  Overview
+  Concepts
+  Designations
+  Relationships
+  Sources
+  Schemas
+  Ontology Browser
+```
+
+## Proposed Nav
+
+```
+Model dropdown:
+  Overview
+  Concepts
+  Designations
+  Relationships
+  Sources
+  Term Types
+  YAML Schema Reference       ← renamed from "Schemas"
+  Entity Field Reference       ← new (after TODO 1)
+  ───────────────────────────  ← separator
+  Ontology Browser             ← moved to bottom, visually separated
+```
+
+Or better: move Ontology Browser to a separate "Tools" dropdown or a standalone nav link:
+
+```
+Nav:  Model ▼  |  Software ▼  |  Tools ▼  |  Docs ▼  |  Blog  |  About
+                                                     ↑
+                                        Ontology Browser, Concept Browser
+```
+
+## Files to Modify
+
+- `.vitepress/config.ts` — Nav configuration

--- a/TODO.infoarch/7-cross-linking.md
+++ b/TODO.infoarch/7-cross-linking.md
@@ -1,0 +1,83 @@
+# 7. Cross-Link Model Docs and Schema Reference
+
+## Problem
+
+The model docs and schema reference are parallel universes with almost no cross-links:
+
+- `concepts.md` describes ManagedConcept fields but doesn't link to the JSON Schema definition or the entity field reference
+- `designations.md` explains the designation hierarchy but doesn't link to the schema
+- `relationships.md` shows relationship types but doesn't link to the YAML examples
+- `sources.md` describes source types but doesn't link to the source schema definition
+- The schema browser has no links back to the conceptual docs
+
+A user reading about Designations in the model docs has no way to jump to the authoritative schema definition of what fields a Designation has. They'd have to navigate to Schemas → find the right definition → expand it.
+
+## Proposed Cross-Links
+
+### From model docs → schema reference
+
+Each conceptual page should link to its corresponding schema entity:
+
+```markdown
+<!-- concepts.md -->
+## ManagedConcept
+
+See the [ManagedConcept schema definition](/docs/model/schemas/yaml-reference#managedconcept) for the authoritative field list.
+
+<!-- designations.md -->
+## Designation Types
+
+See the [Designation schema](/docs/model/schemas/yaml-reference#designation) for all fields.
+
+<!-- sources.md -->
+## ConceptSource
+
+See the [ConceptSource schema](/docs/model/schemas/yaml-reference#conceptsource) for the full field reference.
+```
+
+### From schema reference → model docs
+
+The schema browser should add contextual links:
+
+```markdown
+<!-- In the schema definition for ManagedConcept -->
+Description: "A managed concept entity."
+Link: [Learn about concepts →](/docs/model/concepts)
+```
+
+This requires the schema browser to know which definitions map to which doc pages. Could be a static mapping in the component.
+
+### From examples → model docs
+
+Each example in the sidebar should have a one-line description and link to the relevant concept page:
+
+```markdown
+02-designation-abbreviation.yaml → "Abbreviation designations" → links to /docs/model/designations
+06-related-relationships.yaml → "All relationship types" → links to /docs/model/relationships
+```
+
+## Static Mapping
+
+Add a mapping file or inline map that connects schema `$defs` names to doc page paths:
+
+```ts
+const entityDocLinks: Record<string, string> = {
+  ManagedConcept: '/docs/model/concepts',
+  LocalizedConcept: '/docs/model/concepts',
+  Designation: '/docs/model/designations',
+  Abbreviation: '/docs/model/designations',
+  // ...
+  ConceptSource: '/docs/model/sources',
+  RelationshipType: '/docs/model/relationships',
+  // ...
+}
+```
+
+## Files to Modify
+
+- `docs/model/concepts.md` — Add cross-links to schema reference
+- `docs/model/designations.md` — Add cross-links
+- `docs/model/relationships.md` — Add cross-links
+- `docs/model/sources.md` — Add cross-links
+- `docs/model/term-types.md` — Add cross-links
+- `SchemaReference.vue` — Add doc links to definition headers

--- a/about.md
+++ b/about.md
@@ -107,12 +107,11 @@ Glossarist is used in production by standards bodies including [ISO/TC 211 Geole
 
 ## Get Started
 
-1. **Adopt Glossarist** — Read the [Adoption Guide](/docs/adopt/)
+1. **Explore the Concept Model** — Read the [Concept Model docs](/docs/model/)
 2. **Try the Desktop App** — [Download](/docs/software/desktop) and get started
-3. **Explore the Model** — Read the [Concept Model docs](/docs/model/)
-4. **Explore the Model** — Read the [Concept Model docs](/docs/model/)
-5. **Browse the Ontology** — Explore the [interactive OWL ontology browser](/ontology)
-6. **View on GitHub** — Browse the [source code](https://github.com/glossarist)
+3. **Adopt Glossarist** — Read the [Adoption Guide](/docs/adopt/)
+4. **Browse the Ontology** — Explore the [OWL ontology browser](/docs/model/ontology)
+5. **View on GitHub** — Browse the [source code](https://github.com/glossarist)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,52 +5,42 @@ description: Glossarist documentation
 
 # Documentation
 
-Welcome to Glossarist documentation. Choose a section below to get started.
+Glossarist provides open-source tools for maintaining multi-language concept systems, aligned with ISO standards for terminology management.
 
-## Desktop Application
+## Where to start
 
-Install and use the Glossarist Desktop app to manage concept registries.
+| I want to... | Go to |
+|-------------|-------|
+| Understand the concept model | [Concept Model Overview &rarr;](/docs/model/) |
+| Look up a field or entity type | [Entity Field Reference &rarr;](/docs/model/schemas/entity-fields) |
+| See the YAML schema definitions | [YAML Schema Reference &rarr;](/docs/model/schemas/yaml-reference) |
+| Install the desktop app | [Installation Guide &rarr;](/docs/desktop/getting-started/installation) |
+| Adopt Glossarist in my organization | [Adoption Guide &rarr;](/docs/adopt/) |
+| Browse the code | [Software Ecosystem &rarr;](/docs/software/) |
+| Understand the theory | [Core Concepts &rarr;](/docs/core-concepts/) |
 
-- [Getting Started](/docs/desktop/)
-- [Installation](/docs/desktop/getting-started/installation)
-- [Tutorials](/docs/desktop/tutorials/create-change-request)
+## Sections
 
-## Concept Model
+### [Concept Model](/docs/model/)
 
-The Glossarist concept/term model aligned with ISO standards.
+The Glossarist concept/term model — a self-contained, technology-neutral information model aligned with ISO 10241-1, 704, 30042, 12620, and 25964. Covers concepts, designations, relationships, sources, and term types.
 
-- [Model Overview](/docs/model/)
-- [Concepts](/docs/model/concepts)
-- [Designations](/docs/model/designations)
-- [Relationships](/docs/model/relationships)
+### [Software](/docs/software/)
 
-## Core Concepts
+The Glossarist ecosystem: [glossarist-ruby](/docs/software/glossarist-ruby), [glossarist-js](/docs/software/glossarist-js), [Concept Browser](/docs/software/concept-browser), and the [Desktop App](/docs/software/desktop).
 
-Background on terminology management principles.
+### [Desktop App](/docs/desktop/)
 
-- [Why Concept System?](/docs/core-concepts/intro-to-concept-systems)
-- [Concepts & Terms](/docs/core-concepts/concepts-and-terms)
-- [Registers](/docs/core-concepts/registers)
+Install and use the Glossarist Desktop application to manage concept registries with change request workflows and review.
 
-## Adopting Glossarist
+### [Core Concepts](/docs/core-concepts/)
 
-How to start using Glossarist in your organization.
+Background on terminology management principles: concept systems, the concept-term interaction cycle, and registers.
 
-- [Adoption Guide](/docs/adopt/)
-- [Infrastructure Setup](/docs/adopt/2-infrastructure/)
-- [Migrating Existing Data](/docs/adopt/3-migration/)
+### [Adopting Glossarist](/docs/adopt/)
 
-## Software
+How to start using Glossarist in your organization — workflows, infrastructure setup, and migrating existing data.
 
-Documentation for each piece of the Glossarist ecosystem.
+### [Standards](/docs/standards)
 
-- [glossarist-ruby](/docs/software/glossarist-ruby) — Ruby gem
-- [glossarist-js](/docs/software/glossarist-js) — JavaScript SDK
-- [Concept Browser](/docs/software/concept-browser) — Terminology dataset browser
-- [Desktop App](/docs/software/desktop) — Native desktop editor
-
-## Standards
-
-Which ISO standards Glossarist implements and how.
-
-- [Standards Reference](/docs/standards)
+Which ISO standards Glossarist implements and how each one maps to entities in the concept model.

--- a/docs/model/concepts.md
+++ b/docs/model/concepts.md
@@ -11,38 +11,59 @@ description: ManagedConcept, LocalizedConcept, concept lifecycle, and multi-lang
 
 A `ManagedConcept` is the top-level concept entity in Glossarist. It represents a single concept in the terminology registry.
 
-| Field | Description |
-|-------|-------------|
-| `id` | String identifier for the concept |
-| `uuid` | UUID for the concept |
-| `status` | Normative status of the term |
-| `related` | Array of RelatedConcept |
-| `dates` | Array of ConceptDate |
-| `localized_concepts` | Hash mapping language codes to localized concept UUIDs |
-| `domains` | Array of ConceptReference — upper concepts (subject areas, concept schemes) |
-| `localizations` | Hash mapping language codes to LocalizedConcept instances |
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `identifier` | string | 1..1 | String identifier for the concept |
+| `uri` | anyURI | 0..1 | URI for the concept |
+| `status` | [conceptStatus](/docs/model/schemas/entity-fields) | 0..1 | Lifecycle status |
+| `related` | [RelatedConcept](/docs/model/schemas/entity-fields)[] | 0..* | Related concepts |
+| `dates` | [ConceptDate](/docs/model/schemas/entity-fields)[] | 0..* | Governance events |
+| `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Concept-level sources |
+| `domains` | [Reference](/docs/model/schemas/entity-fields)[] | 0..* | Subject area references |
+| `localizations` | [LocalizedConcept](#localizedconcept){} | 0..* | Per-language data (keyed by language code) |
 
 ## LocalizedConcept
 
 Localizations of the concept to different languages. Each language has its own definition, notes, examples, terms, and revision history.
 
-| Field | Description |
-|-------|-------------|
-| `id` | Optional identifier for cross-references |
-| `uuid` | UUID |
-| `designations` | Array of Designations under which the concept is known |
-| `domain` | URI reference to the subject area |
-| `related` | Per-language concept relationships |
-| `subject` | Subject of the term |
-| `definition` | Array of DetailedDefinition |
-| `non_verb_rep` | Array of non-verbal representations |
-| `notes` | Zero or more notes |
-| `examples` | Zero or more examples |
-| `language_code` | ISO-639 3-letter language code |
-| `script` | ISO 15924 4-letter script code (optional) |
-| `system` | ISO 24229 conversion system code (optional) |
-| `entry_status` | `notValid`, `valid`, `superseded`, or `retired` |
-| `classification` | `preferred`, `admitted`, or `deprecated` |
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `language` | string | 0..1 | ISO 639 3-letter language code |
+| `script` | string | 0..1 | ISO 15924 4-letter script code |
+| `system` | string | 0..1 | ISO 24229 conversion system code |
+| `designations` | [Designation](/docs/model/designations)[] | 0..* | Terms under which the concept is known |
+| `definition` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Definitions |
+| `notes` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Notes |
+| `examples` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Examples |
+| `entry_status` | [entryStatus](/docs/model/schemas/entity-fields) | 0..1 | `notValid`, `valid`, `superseded`, or `retired` |
+| `classification` | string | 0..1 | `preferred`, `admitted`, or `deprecated` |
+| `domain` | anyURI | 0..1 | URI reference to the subject area |
+| `related` | [RelatedConcept](/docs/model/schemas/entity-fields)[] | 0..* | Per-language concept relationships |
+| `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Per-language sources |
+| `references` | [Reference](/docs/model/schemas/entity-fields)[] | 0..* | Typed references |
+| `dates` | [ConceptDate](#conceptdate)[] | 0..* | Per-language governance events |
+| `release` | string | 0..1 | Release version |
+| `review_type` | string | 0..1 | `editorial` or `substantive` |
+| `lineage_similarity` | integer | 0..1 | Lineage similarity score |
+
+## DetailedDefinition
+
+A definition, note, or example with optional per-item sources.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `content` | string | 1..1 | The text content |
+| `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Per-item sources |
+
+## ConceptDate
+
+A governance event in the concept lifecycle.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `date` | dateTime | 1..1 | Date and time of the event |
+| `type` | [dateType](/docs/model/schemas/entity-fields) | 1..1 | Event type (`accepted`, `amended`, `retired`, `review`, `reviewDecision`) |
+| `description` | string | 0..1 | Event description |
 
 ## Concept lifecycle
 
@@ -61,3 +82,5 @@ A single ManagedConcept can have localizations in any number of languages. Diffe
 ## ManagedConceptCollection
 
 A collection for managed concepts. Includes the Ruby `Enumerable` module. Supports loading from and saving to YAML file datasets.
+
+See the [YAML Schema Reference](/docs/model/schemas/yaml-reference) for the complete JSON Schema definitions, or the [Entity Field Reference](/docs/model/schemas/entity-fields) for all entity types with types, cardinality, and allowed values.

--- a/docs/model/designations.md
+++ b/docs/model/designations.md
@@ -23,30 +23,75 @@ Designations form a **MECE** (Mutually Exclusive, Collectively Exhaustive) hiera
 
 ## Base properties (common to all types)
 
-| Property | Standard | Description |
-|----------|----------|-------------|
-| `designation` | — | The term text or symbol |
-| `normative_status` | — | `preferred`, `admitted`, `deprecated`, or `superseded` |
-| `geographical_area` | ISO 3166-1 | Geographic usage region |
-| `language` | ISO 639 | Language of this designation |
-| `script` | ISO 15924 | Script of the designation text (e.g. `Latn`, `Cyrl`) |
-| `system` | ISO 24229 | Conversion system code |
-| `international` | — | Whether used internationally |
-| `absent` | — | Whether intentionally absent in this language |
-| `pronunciation` | — | Collection of Pronunciation entries |
-| `sources` | ISO 10241-1 §6.8 | Collection of ConceptSource entries |
-| `term_type` | ISO 12620 | Optional classification of the designation's term type |
-| `related` | — | Collection of RelatedConcept for designation-level relationships |
-| `register` | — | Register information |
+Every designation type inherits these fields from the `Designation` base:
+
+| Field | Type | Card. | Standard | Description |
+|-------|------|-------|----------|-------------|
+| `designation` | string | 1..1 | — | The term text or symbol |
+| `normative_status` | [normativeStatus](/docs/model/schemas/entity-fields) | 0..1 | — | `preferred`, `admitted`, `deprecated`, or `superseded` |
+| `term_type` | [termType](/docs/model/term-types) | 0..1 | ISO 12620 | Classification of the designation's term type |
+| `related` | [RelatedConcept](/docs/model/schemas/entity-fields)[] | 0..* | — | Designation-level concept relationships |
+| `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | ISO 10241-1 §6.8 | Bibliographic sources |
+| `pronunciation` | [Pronunciation](#pronunciation)[] | 0..* | — | Pronunciation entries |
+| `language` | string | 0..1 | ISO 639 | Language of this designation |
+| `script` | string | 0..1 | ISO 15924 | Script of the designation text (e.g. `Latn`, `Cyrl`) |
+| `system` | string | 0..1 | ISO 24229 | Conversion system code |
+| `international` | boolean | 0..1 | — | Whether used internationally |
+| `absent` | boolean | 0..1 | — | Whether intentionally absent in this language |
+| `register` | string | 0..1 | — | Register information |
+
+## Expression-specific fields
+
+Expression designations add:
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `grammar_info` | [GrammarInfo](#grammar-information)[] | 0..* | Grammatical information |
+
+## Abbreviation-specific fields
+
+Abbreviation designations (extends Expression) add:
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `is_acronym` | boolean | 0..1 | Whether this is an acronym |
+| `is_initialism` | boolean | 0..1 | Whether this is an initialism |
+| `is_truncation` | boolean | 0..1 | Whether this is a truncation |
+
+## Symbol-specific fields
+
+Symbol designations add:
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `text` | string | 0..1 | Text representation of the symbol |
+
+Graphical symbols add:
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `image` | anyURI | 0..1 | Image URI for the graphical symbol |
 
 ## Pronunciation
 
 Each Pronunciation entry has:
 
-| Attribute | Standard | Description |
-|-----------|----------|-------------|
-| `content` | — | The pronunciation text |
-| `language` | ISO 639 | Language/dialect being pronounced (3-letter code) |
-| `script` | ISO 15924 | Script of the pronunciation text (4-letter code) |
-| `country` | ISO 3166-1 | Country variant (2-letter code, optional) |
-| `system` | ISO 24229 | Conversion system code (e.g. `IPA`, `Var:jpn-Hrkt:Latn:Hepburn-1886`) |
+| Field | Type | Card. | Standard | Description |
+|-------|------|-------|----------|-------------|
+| `content` | string | 1..1 | — | The pronunciation text |
+| `language` | string | 0..1 | ISO 639 | Language/dialect being pronounced (3-letter code) |
+| `script` | string | 0..1 | ISO 15924 | Script of the pronunciation text (4-letter code) |
+| `country` | string | 0..1 | ISO 3166-1 | Country variant (2-letter code) |
+| `system` | string | 0..1 | ISO 24229 | Conversion system code (e.g. `IPA`, `Var:jpn-Hrkt:Latn:Hepburn-1886`) |
+
+## Grammar Information
+
+Each GrammarInfo entry has:
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `gender` | [gender](/docs/model/schemas/entity-fields) | 0..* | Grammatical gender |
+| `number` | [number](/docs/model/schemas/entity-fields) | 0..* | Grammatical number |
+| `part_of_speech` | string | 0..1 | Part of speech |
+
+See the [YAML Schema Reference](/docs/model/schemas/yaml-reference) for the complete JSON Schema definitions, or the [Entity Field Reference](/docs/model/schemas/entity-fields) for all entity types.

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -54,7 +54,7 @@ fra:
       status: identical
 ```
 
-See the [YAML Schema Reference](/docs/model/schemas) for complete field documentation, enum values, and V2/V3 differences.
+See the [YAML Schema Reference](/docs/model/schemas/yaml-reference) for complete field documentation and enum values, or the [Entity Field Reference](/docs/model/schemas/entity-fields) for per-entity field lists with types and cardinality.
 
 ## Standards alignment
 
@@ -102,5 +102,7 @@ puts concept.localizations['eng'].definition
 - [Relationships](/docs/model/relationships) — Typed relationship kinds across 4 standards
 - [Sources](/docs/model/sources) — Authoritative source hierarchy and provenance
 - [Term Types](/docs/model/term-types) — ISO 12620 term type classifications
-- [Schemas](/docs/model/schemas) — V2 and V3 YAML schema reference and enum values
-- [Ontology Browser](/ontology) — Interactive ontology and SHACL shape browser
+- [YAML Schemas](/docs/model/schemas/) — V2 and V3 schema overview and examples
+- [YAML Schema Browser](/docs/model/schemas/yaml-reference) — Interactive JSON Schema definitions
+- [Entity Field Reference](/docs/model/schemas/entity-fields) — Per-entity field reference with types and cardinality
+- [Ontology Browser](/docs/model/ontology) — Interactive OWL ontology and SHACL shape browser

--- a/docs/model/ontology.md
+++ b/docs/model/ontology.md
@@ -1,13 +1,7 @@
 ---
 title: Ontology Browser
-description: Interactive browser for the Glossarist OWL ontology, SHACL shapes, and SKOS taxonomy.
+description: Interactive browser for the Glossarist OWL ontology, SHACL shapes, and SKOS taxonomy
 layout: page
 ---
 
-<script setup>
-if (typeof window !== 'undefined') {
-  window.location.replace('/ontology')
-}
-</script>
-
-Redirecting to the [Ontology Browser](/ontology)&hellip;
+<OntologyBrowser />

--- a/docs/model/relationships.md
+++ b/docs/model/relationships.md
@@ -130,3 +130,5 @@ Types without a direct SKOS equivalent (`compare`, `contrast`, `see`, `deprecate
 2. **No overlap with SKOS** — Where SKOS defines a property, Glossarist reuses the exact same semantics (e.g., `broader` = `skos:broader`)
 3. **Directional** — Every relationship has a source and target; inverse pairs are separate types (`broader`/`narrower`, `supersedes`/`superseded_by`)
 4. **Typed hierarchy** — The three ISO 25964 hierarchy types (generic, partitive, instantial) are distinct because they carry different semantic meaning and affect how concept trees are rendered
+
+See the [YAML Schema Reference](/docs/model/schemas/yaml-reference) for the JSON Schema definition of the RelatedConcept entity, or the [Entity Field Reference](/docs/model/schemas/entity-fields) for field-level details.

--- a/docs/model/schemas/entity-fields.md
+++ b/docs/model/schemas/entity-fields.md
@@ -1,0 +1,10 @@
+---
+title: Entity Field Reference
+description: Field-level reference for every Glossarist entity type — types, cardinality, allowed values, and YAML examples
+---
+
+# Entity Field Reference
+
+The tables below show each entity type's fields and all controlled vocabularies, derived from the concept model's OWL ontology. The concept model is formally expressed as SHACL shapes for validation — these shapes define the fields, types, and cardinality of every entity in a concept YAML file.
+
+<YamlSchemas />

--- a/docs/model/schemas/index.md
+++ b/docs/model/schemas/index.md
@@ -1,9 +1,9 @@
 ---
-title: YAML Schema Reference
-description: JSON Schema definitions for Glossarist concept data — V2 and V3 YAML format, field reference, enum values, and examples
+title: YAML Schemas
+description: JSON Schema definitions for Glossarist concept data — V2 and V3 format, examples, and field reference
 ---
 
-# YAML Schema Reference
+# YAML Schemas
 
 Glossarist concept data is stored as YAML files validated against [JSON Schema](https://json-schema.org/) definitions. The canonical schemas live in the [concept-model repository](https://github.com/glossarist/concept-model/tree/main/schemas).
 
@@ -14,9 +14,12 @@ The concept model has two major schema versions:
 
 Both formats are supported by [glossarist-ruby](/docs/software/glossarist-ruby) and [glossarist-js](/docs/software/glossarist-js) for reading and writing.
 
-## JSON Schema
+## Reference
 
-<SchemaReference />
+| Section | Description |
+|---------|-------------|
+| [YAML Schema Reference](/docs/model/schemas/yaml-reference) | Interactive browser for JSON Schema definitions — properties, types, enums, and definitions for V2 and V3 |
+| [Entity Field Reference](/docs/model/schemas/entity-fields) | Field-level reference for every entity type, with types, cardinality, and allowed values |
 
 ## Examples
 
@@ -42,9 +45,3 @@ Each schema feature is demonstrated with standalone YAML examples in the concept
 
 - [V3 examples (GitHub)](https://github.com/glossarist/concept-model/tree/main/schemas/v3/examples)
 - [V2 examples (GitHub)](https://github.com/glossarist/concept-model/tree/main/schemas/v2/examples)
-
-## Ontology Entity View
-
-The tables below show each entity type's fields and all controlled vocabularies, derived from the concept model's OWL ontology.
-
-<YamlSchemas />

--- a/docs/model/schemas/yaml-reference.md
+++ b/docs/model/schemas/yaml-reference.md
@@ -1,0 +1,10 @@
+---
+title: YAML Schema Reference
+description: Interactive JSON Schema browser for Glossarist concept data — V2 and V3 properties, types, enums, and definitions
+---
+
+# YAML Schema Reference
+
+Browse the JSON Schema definitions for Glossarist concept data. Select a version and schema to see properties, types, enum values, and expandable definitions.
+
+<SchemaReference />

--- a/docs/model/sources.md
+++ b/docs/model/sources.md
@@ -9,6 +9,15 @@ description: Multi-level source hierarchy for bibliographic references in termin
 
 An **authoritative source** is the "source of truth" for a terminological entry or any of its parts. It is the bibliographic reference from which the content originates, represented in the model by the `ConceptSource` class.
 
+## ConceptSource fields
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `type` | [sourceType](/docs/model/schemas/entity-fields) | 0..1 | `authoritative` or `lineage` |
+| `status` | [sourceStatus](/docs/model/schemas/entity-fields) | 0..1 | Relationship between entry content and source |
+| `origin` | [Citation](#citation) | 0..1 | The bibliographic citation |
+| `modification` | string | 0..1 | Description of changes made relative to the source |
+
 ## Source type
 
 Each `ConceptSource` carries a `type` attribute distinguishing between two kinds of source:
@@ -34,6 +43,47 @@ The `status` attribute describes the relationship between the entry content and 
 
 The optional `modification` attribute can provide a description of any change made relative to the cited source.
 
+## Citation
+
+A bibliographic citation with structured reference, locality, and optional link.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `ref` | [CitationRef](#citation-reference) | 0..1 | Structured citation reference (source + id + optional version) |
+| `locality` | [Locality](#locality) | 0..1 | Location within the cited document |
+| `link` | anyURI | 0..1 | URL to the cited document |
+| `original` | string | 0..1 | Original text from the source |
+| `custom_locality` | [CustomLocality](#custom-locality)[] | 0..* | Custom name-value locality pairs |
+
+### Citation Reference
+
+A structured reference to a source document.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `source` | string | 0..1 | The source document identifier |
+| `id` | string | 0..1 | The specific identifier within the source |
+| `version` | string | 0..1 | Version of the source |
+
+### Locality
+
+A location within a cited document (section, clause, page, etc.).
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `type` | string | 1..1 | Locality type (e.g. `section`, `clause`, `page`) |
+| `reference_from` | string | 0..1 | Start of the locality range |
+| `reference_to` | string | 0..1 | End of the locality range |
+
+### Custom Locality
+
+A custom name-value locality pair within a citation.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `name` | string | 1..1 | The locality name |
+| `value` | string | 1..1 | The locality value |
+
 ## Multi-level source hierarchy
 
 Sources can be attached at multiple levels of the model:
@@ -41,7 +91,7 @@ Sources can be attached at multiple levels of the model:
 | Level | Scope |
 |-------|-------|
 | `ManagedConcept.sources` | Applicable to the concept as a whole |
-| `Concept.sources` | Applicable to a specific language version |
+| `LocalizedConcept.sources` | Applicable to a specific language version |
 | `Designation.sources` | Sources for individual terms |
 | `DetailedDefinition.sources` | Sources for individual definitions, notes, or examples |
 | `NonVerbRep.sources` | Sources for non-verbal representations |
@@ -51,3 +101,5 @@ This hierarchy means that a concept may have multiple authoritative sources. A c
 ## The glossary as authoritative source
 
 In some cases, the glossary itself is the authoritative source — when a term and its definition originate within the glossary rather than being adopted from an external standard.
+
+See the [YAML Schema Reference](/docs/model/schemas/yaml-reference) for the complete JSON Schema definitions, or the [Entity Field Reference](/docs/model/schemas/entity-fields) for all entity types.

--- a/docs/model/term-types.md
+++ b/docs/model/term-types.md
@@ -5,7 +5,7 @@ description: ISO 12620 / TBX term type classifications for designations
 
 # Term Types
 
-ISO 12620 / TBX `term_type` classification for designations. These types are organized into three categories:
+ISO 12620 / TBX `term_type` classification for [designations](/docs/model/designations). These types are organized into three categories:
 
 ## Orthographic / structural
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -64,5 +64,8 @@ Glossarist maintains compatibility with IEC Electropedia data format, including 
 ## Cross-references
 
 - [Concept Model documentation](/docs/model/)
+- [YAML Schema Reference](/docs/model/schemas/yaml-reference)
+- [Entity Field Reference](/docs/model/schemas/entity-fields)
+- [Ontology Browser](/docs/model/ontology)
 - [Software implementations](/docs/software/)
 - [Concept model repository](https://github.com/glossarist/concept-model)

--- a/ontology.md
+++ b/ontology.md
@@ -1,7 +1,0 @@
----
-title: Ontology Browser
-description: Interactive browser for the Glossarist OWL ontology, SHACL shapes, and SKOS taxonomy.
-layout: page
----
-
-<OntologyBrowser />


### PR DESCRIPTION
Implements all 7 items from the IA audit (TODO.infoarch/).

**Changes:**

1. **Split schemas page** — `schemas.md` → `schemas/` directory with 3 dedicated pages:
   - `schemas/index.md` — overview, V2/V3 intro, examples table
   - `schemas/yaml-reference.md` — full-page schema browser (SchemaReference)
   - `schemas/entity-fields.md` — entity field reference (YamlSchemas)

2. **Move ontology into docs tree** — OntologyBrowser moved from `/ontology` (orphaned root page) to `/docs/model/ontology` (proper docs page with sidebar). Removed redirect hack.

3. **Add entity field tables to model pages** — `concepts.md`, `designations.md`, `sources.md` now have authoritative field tables with types, cardinality, and cross-links.

4. **Redesign docs landing page** — `docs/index.md` now has a guided paths table ("I want to... → Go to") instead of a flat link dump.

5. **Fix about page** — Removed duplicate Get Started step, reordered steps, updated links.

6. **Restructure nav and sidebar** — Model nav dropdown now includes Term Types, YAML Schema Reference, Entity Field Reference, and Ontology Browser. Model sidebar split into Concept Model and Schema Reference groups.

7. **Cross-link everything** — Added bidirectional links between model docs, schema reference, entity fields, and ontology browser. Updated ModelLanding, standards, relationships, term-types pages.