### PR TITLE
fix: use page layout for schema browser and entity fields

### DIFF
--- a/docs/model/schemas/entity-fields.md
+++ b/docs/model/schemas/entity-fields.md
@@ -1,10 +1,13 @@
 ---
 title: Entity Field Reference
 description: Field-level reference for every Glossarist entity type — types, cardinality, allowed values, and YAML examples
+layout: page
 ---
 
 # Entity Field Reference
 
 The tables below show each entity type's fields and all controlled vocabularies, derived from the concept model's OWL ontology. The concept model is formally expressed as SHACL shapes for validation — these shapes define the fields, types, and cardinality of every entity in a concept YAML file.
+
+[&larr; Back to YAML Schemas](/docs/model/schemas/) &middot; [YAML Schema Browser](/docs/model/schemas/yaml-reference) &middot; [Ontology Browser](/docs/model/ontology)
 
 <YamlSchemas />

--- a/docs/model/schemas/yaml-reference.md
+++ b/docs/model/schemas/yaml-reference.md
@@ -1,10 +1,13 @@
 ---
 title: YAML Schema Reference
 description: Interactive JSON Schema browser for Glossarist concept data — V2 and V3 properties, types, enums, and definitions
+layout: page
 ---
 
 # YAML Schema Reference
 
 Browse the JSON Schema definitions for Glossarist concept data. Select a version and schema to see properties, types, enum values, and expandable definitions.
+
+[&larr; Back to YAML Schemas](/docs/model/schemas/) &middot; [Entity Field Reference](/docs/model/schemas/entity-fields) &middot; [Ontology Browser](/docs/model/ontology)
 
 <SchemaReference />


### PR DESCRIPTION
Schema browser and entity fields pages are full-width interactive tools with their own internal navigation. Using the docs layout created a cramped double-sidebar. Now uses `layout: page` like the ontology browser. Added navigation back-links to compensate for the missing docs sidebar.