### PR TITLE
feat: update docs for DesignationRelationship, annotations, 52 relationship types

### DIFF
--- a/.vitepress/theme/components/RelationshipTypes.vue
+++ b/.vitepress/theme/components/RelationshipTypes.vue
@@ -4,33 +4,70 @@ import type { TaxonomyConcept } from '../../data/types'
 import { useOntologyData } from '../../data/useOntologyData'
 
 const categories: { key: string; label: string; types: string[] }[] = [
-  { key: 'generic', label: 'Hierarchical — Generic (BTG/NTG)', types: ['broader', 'narrower', 'broader_generic', 'narrower_generic'] },
-  { key: 'partitive', label: 'Hierarchical — Partitive (BTP/NTP)', types: ['broader_partitive', 'narrower_partitive'] },
-  { key: 'instantial', label: 'Hierarchical — Instantial (BTI/NTI)', types: ['broader_instantial', 'narrower_instantial'] },
-  { key: 'associative', label: 'Associative', types: ['see', 'related_concept', 'related_concept_broader', 'related_concept_narrower', 'compare', 'contrast'] },
-  { key: 'equivalence', label: 'Equivalence and Mapping', types: ['equivalent', 'exact_match', 'close_match', 'broad_match', 'narrow_match', 'related_match'] },
-  { key: 'spatiotemporal', label: 'Spatiotemporal', types: ['sequentially_related_concept', 'spatially_related_concept', 'temporally_related_concept'] },
-  { key: 'lifecycle', label: 'Lifecycle', types: ['deprecates', 'supersedes', 'superseded_by'] },
-  { key: 'lexical', label: 'Lexical and Designation-level', types: ['homograph', 'false_friend', 'abbreviated_form_for', 'short_form_for'] },
+  { key: 'hierarchical', label: 'Hierarchical — Generic (SKOS)', types: ['broader', 'narrower', 'broader_generic', 'narrower_generic'] },
+  { key: 'partitive', label: 'Hierarchical — Partitive (ISO 25964 / ISO 19135)', types: ['broader_partitive', 'narrower_partitive', 'has_part', 'is_part_of'] },
+  { key: 'instantial', label: 'Hierarchical — Instantial (ISO 25964 / ISO 19135)', types: ['broader_instantial', 'narrower_instantial', 'instance_of', 'has_instance'] },
+  { key: 'register', label: 'Register Management (ISO 19135)', types: ['has_concept', 'is_concept_of', 'inherits', 'inherited_by'] },
+  { key: 'mapping', label: 'Equivalence and Mapping (SKOS)', types: ['equivalent', 'exact_match', 'close_match', 'broad_match', 'narrow_match', 'related_match'] },
+  { key: 'associative', label: 'Associative (ISO 10241-1 / ISO 25964)', types: ['see', 'related_concept', 'related_concept_broader', 'related_concept_narrower', 'references'] },
+  { key: 'lifecycle', label: 'Lifecycle (ISO 10241-1 / ISO 19135)', types: ['supersedes', 'superseded_by', 'deprecates', 'deprecated_by', 'replaces', 'replaced_by', 'invalidates', 'invalidated_by', 'retires', 'retired_by'] },
+  { key: 'comparative', label: 'Comparative (ISO 10241-1)', types: ['compare', 'contrast'] },
+  { key: 'versioning', label: 'Versioning and Definitional (ISO 19135)', types: ['has_definition', 'definition_of', 'has_version', 'version_of', 'current_version', 'current_version_of'] },
+  { key: 'spatiotemporal', label: 'Spatiotemporal (ISO 25964 / TBX)', types: ['sequentially_related', 'spatially_related', 'temporally_related'] },
+  { key: 'lexical', label: 'Lexical (ISO 12620 / TBX)', types: ['homograph', 'false_friend'] },
+  { key: 'designation', label: 'Designation-level (ISO 10241-1)', types: ['abbreviated_form_for', 'short_form_for'] },
 ]
 
 const inverses: Record<string, string> = {
+  // Generic hierarchical
   broader: 'narrower',
   narrower: 'broader',
   broader_generic: 'narrower_generic',
   narrower_generic: 'broader_generic',
+  // Partitive
   broader_partitive: 'narrower_partitive',
   narrower_partitive: 'broader_partitive',
+  has_part: 'is_part_of',
+  is_part_of: 'has_part',
+  // Instantial
   broader_instantial: 'narrower_instantial',
   narrower_instantial: 'broader_instantial',
+  instance_of: 'has_instance',
+  has_instance: 'instance_of',
+  // Register management
+  has_concept: 'is_concept_of',
+  is_concept_of: 'has_concept',
+  inherits: 'inherited_by',
+  inherited_by: 'inherits',
+  has_definition: 'definition_of',
+  definition_of: 'has_definition',
+  // Versioning
+  has_version: 'version_of',
+  version_of: 'has_version',
+  current_version: 'current_version_of',
+  current_version_of: 'current_version',
+  // Lifecycle
   supersedes: 'superseded_by',
   superseded_by: 'supersedes',
+  deprecates: 'deprecated_by',
+  deprecated_by: 'deprecates',
+  replaces: 'replaced_by',
+  replaced_by: 'replaces',
+  invalidates: 'invalidated_by',
+  invalidated_by: 'invalidates',
+  retires: 'retired_by',
+  retired_by: 'retires',
+  // Mapping
   broad_match: 'narrow_match',
   narrow_match: 'broad_match',
+  // Symmetric (self-inverse)
   exact_match: 'exact_match',
   close_match: 'close_match',
   related_match: 'related_match',
   equivalent: 'equivalent',
+  compare: 'compare',
+  contrast: 'contrast',
+  related_concept: 'related_concept',
 }
 
 const { taxonomies, loaded } = useOntologyData()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,11 @@ Uses **npm** with `"type": "module"`.
 │       ├── BlogIndex.vue      # Blog listing with cards
 │       ├── BlogByline.vue     # Author/date display for blog posts
 │       └── ReleaseDownloader.vue  # GitHub release fetcher with OS detection
+│       └── RelationshipTypes.vue  # 52 relationship types browser (categories, inverses, taxonomy data)
 ├── data/
-│   └── projects.ts        # Software project data (name, version, description, links)
+│   ├── projects.ts        # Software project data (name, version, description, links)
+│   ├── types.ts            # TypeScript types for taxonomy concepts
+│   └── useOntologyData.ts  # Composable loading taxonomies.json into Vue reactive state
 └── posts.data.ts          # Blog content loader (createContentLoader)
 ```
 
@@ -55,6 +58,7 @@ Configured per-section in `config.ts`. Each docs section has its own sidebar. Th
 - `ReleaseDownloader` — Client-side fetch of latest GitHub release via REST API, with localStorage caching (1h TTL) and OS detection from `navigator.userAgent`
 - `HomePage` — Hero section, software cards grid (driven by `projects.ts`), "used by" section, features grid
 - `BlogIndex` / `BlogByline` — Blog listing and post bylines, driven by `posts.data.ts`
+- `RelationshipTypes` — 52 relationship types browser with categories, inverse pairs, and alphabetical reference. Reads from `public/data/taxonomies.json` via `useOntologyData` composable.
 
 ### Styling
 

--- a/docs/model/concepts.md
+++ b/docs/model/concepts.md
@@ -34,6 +34,7 @@ Localizations of the concept to different languages. Each language has its own d
 | `designations` | [Designation](/docs/model/designations)[] | 0..* | Terms under which the concept is known |
 | `definition` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Definitions |
 | `notes` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Notes |
+| `annotations` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Editorial annotations (distinct from notes) |
 | `examples` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Examples |
 | `entry_status` | [entryStatus](/reference/entity-fields) | 0..1 | `notValid`, `valid`, `superseded`, or `retired` |
 | `classification` | string | 0..1 | `preferred`, `admitted`, or `deprecated` |

--- a/docs/model/designations.md
+++ b/docs/model/designations.md
@@ -30,7 +30,7 @@ Every designation type inherits these fields from the `Designation` base:
 | `designation` | string | 1..1 | — | The term text or symbol |
 | `normative_status` | [normativeStatus](/reference/entity-fields) | 0..1 | — | `preferred`, `admitted`, `deprecated`, or `superseded` |
 | `term_type` | [termType](/docs/model/term-types) | 0..1 | ISO 12620 | Classification of the designation's term type |
-| `related` | [RelatedConcept](/reference/entity-fields)[] | 0..* | — | Designation-level concept relationships |
+| `related` | [DesignationRelationship](#designation-relationships)[] | 0..* | ISO 10241-1 | Designation-level relationships (e.g. abbreviated_form_for) |
 | `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | ISO 10241-1 §6.8 | Bibliographic sources |
 | `pronunciation` | [Pronunciation](#pronunciation)[] | 0..* | — | Pronunciation entries |
 | `language` | string | 0..1 | ISO 639 | Language of this designation |
@@ -93,5 +93,31 @@ Each GrammarInfo entry has:
 | `gender` | [gender](/reference/entity-fields) | 0..* | Grammatical gender |
 | `number` | [number](/reference/entity-fields) | 0..* | Grammatical number |
 | `part_of_speech` | string | 0..1 | Part of speech |
+
+## Designation Relationships
+
+Designation-level relationships link designations of the **same concept** to each other (e.g. an abbreviation to its full form). They are distinct from concept-level [RelatedConcept](/reference/entity-fields#entity-RelatedConcept) links, which connect entire concepts by identifier.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `type` | string (enum) | 1..1 | `abbreviated_form_for` or `short_form_for` |
+| `content` | string | 0..1 | Text describing the relationship |
+| `target` | string | 0..1 | The target designation text |
+
+### Example
+
+```yaml
+terms:
+  - type: expression
+    designation: Light Emitting Diode
+    normative_status: preferred
+  - type: abbreviation
+    designation: LED
+    normative_status: admitted
+    acronym: true
+    related:
+      - type: abbreviated_form_for
+        target: Light Emitting Diode
+```
 
 See the [YAML Schema Reference](/reference/schema-browser) for the complete JSON Schema definitions, the [Entity Field Reference](/reference/entity-fields) for all entity types, and the [Standards compliance reference](/docs/standards) for ISO standard mappings.

--- a/docs/model/relationships.md
+++ b/docs/model/relationships.md
@@ -7,7 +7,7 @@ description: Typed semantic relationship types between concepts, defined by the 
 
 Concepts in Glossarist are connected by **typed semantic relationships** — directional links that express how one concept relates to another. Every relationship has a type, a source concept, and a target concept. See the [RelatedConcept entity definition](/reference/entity-fields#entity-RelatedConcept) for the authoritative field list.
 
-This page documents all relationship types organized by category, their ISO/SKOS alignment, and how to author them in YAML. The relationship definitions are derived from the Glossarist concept model.
+This page documents all relationship types organized by category, their ISO/SKOS alignment, and how to author them in YAML. The relationship definitions are derived from the [Glossarist concept model ontology](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/relationship-type.ttl).
 
 ## Overview
 
@@ -17,6 +17,7 @@ Relationships serve several purposes:
 - **Reasoning** — Hierarchical relationships enable inheritance of properties across the concept tree
 - **Interoperability** — Standard relationship types map to SKOS and ISO 25964 properties for cross-vocabulary exchange
 - **Provenance** — Lifecycle relationships track how concepts evolve over time (superseded, deprecated)
+- **Cross-dataset linking** — Relationships connect concepts across datasets and editions (e.g., VIM editions, G18 to VIM/VIML)
 
 Each relationship is directional: `A --[type]--> B` means "A has relationship type to B." Many types have an inverse: if A `broader` B, then B `narrower` A.
 
@@ -82,6 +83,24 @@ related:
     content: "3.1.1.0"            # This concept supersedes 3.1.1.0
 ```
 
+### Cross-dataset relationships
+
+When linking to a concept in a different dataset, use the `ref` object with a `source` URN and concept `id`:
+
+```yaml
+related:
+  - type: supersedes
+    ref:
+      source: urn:oiml:pub:v:1:2013
+      id: '2.1'
+  - type: see
+    ref:
+      source: urn:oiml:pub:v:2-200:2012
+      id: '2.13'
+```
+
+The `source` URN identifies the target dataset, and `id` is the concept identifier within that dataset. The concept-browser resolves these at build time into navigable cross-dataset edges.
+
 ### Multiple relationships
 
 A concept can have many relationships of different types:
@@ -99,6 +118,87 @@ related:
   - type: exact_match
     content: "iso-tc211:entity"
 ```
+
+### Designation-level relationships
+
+Designation-level relationships (`abbreviated_form_for`, `short_form_for`) link designations of the **same concept** to each other. They appear on designations rather than concepts, and use `target` (designation text) instead of `ref` (concept identifier).
+
+```yaml
+terms:
+  - type: expression
+    designation: Light Emitting Diode
+    normative_status: preferred
+  - type: abbreviation
+    designation: LED
+    normative_status: admitted
+    acronym: true
+    related:
+      - type: abbreviated_form_for
+        target: Light Emitting Diode
+```
+
+See [Designations](/docs/model/designations#designation-relationships) for the full DesignationRelationship model. The `ref.text` field on concept-level relationships serves a different purpose — it provides designation text when the concept is identified by text rather than by registry reference.
+
+## Inverse Derivation
+
+Glossarist derives inverse relationships automatically from the relationship graph. When concept A declares `supersedes` concept B, the system derives `superseded_by` on concept B at render time — without requiring the inverse to be explicitly authored.
+
+This means you only author the forward direction. Inverse relationships appear in the concept-browser automatically:
+
+| Authored type | Derived inverse |
+|---|---|
+| `supersedes` | `superseded_by` |
+| `deprecates` | `deprecated_by` |
+| `replaces` | `replaced_by` |
+| `invalidates` | `invalidated_by` |
+| `retires` | `retired_by` |
+| `broader` | `narrower` |
+| `has_part` | `is_part_of` |
+| `instance_of` | `has_instance` |
+| `has_version` | `version_of` |
+
+Symmetric types (`equivalent`, `compare`, `contrast`, `close_match`, `related_match`, `related_concept`) are their own inverse — no derivation needed.
+
+## Cross-Dataset Navigation
+
+Glossarist's concept-browser supports **cross-dataset relationships** — links between concepts in different datasets loaded from the same deployment. This enables multi-edition navigation for terminology systems like OIML VIM/VIML.
+
+### How it works
+
+1. Each dataset defines concepts with unique URNs (e.g., `urn:oiml:pub:v:1:2022`)
+2. Concepts declare `related` entries using `ref.source` to target a different dataset
+3. At build time, the concept-browser resolves all cross-dataset references into an edge graph
+4. The UI renders these as navigable links with category-colored badges
+
+### Example: VIM multi-edition navigation
+
+The OIML VIM (International Vocabulary of Metrology) has four editions (1993, 2007, 2010, 2012). Each edition is a separate dataset. Concepts in newer editions declare `supersedes` relationships to their predecessors:
+
+```yaml
+# In datasets/vim-2012/concepts/2.13.yaml
+related:
+  - type: supersedes
+    ref:
+      source: urn:oiml:pub:v:2-200:2007
+      id: '2.13'
+```
+
+When rendered, the VIM 2012 concept 2.13 shows a "supersedes" link to VIM 2007 concept 2.13, and the VIM 2007 concept automatically shows "superseded by" pointing back.
+
+### Example: G18 cross-references to VIM/VIML
+
+OIML G 18 is an alphabetical glossary of 2132 terms sourced from 88 OIML publications. Many terms originate from VIM or VIML. Cross-dataset `see` relationships link G18 terms to their authoritative definitions:
+
+```yaml
+# In datasets/g18/concepts/00079.yaml (measuring instrument)
+related:
+  - type: see
+    ref:
+      source: urn:oiml:pub:v:2-200:2007
+      id: '3.1'
+```
+
+This enables users navigating G18 to jump directly to the authoritative VIM definition with full notes and examples.
 
 ## SKOS Alignment
 
@@ -122,13 +222,14 @@ Glossarist relationship types map to standard SKOS and ISO 25964 ontology proper
 | `related_concept` | `skos:semanticRelation` | General associative |
 | `equivalent` | `skos:exactMatch` | Within-vocabulary |
 
-Types without a direct SKOS equivalent (`compare`, `contrast`, `see`, `deprecates`, `supersedes`, `homograph`, `false_friend`, etc.) are expressed as `gloss:` properties in the Glossarist OWL ontology and serialized as-is in TBX output using the corresponding TBX data category.
+Types without a direct SKOS equivalent (`compare`, `contrast`, `see`, `deprecates`, `supersedes`, `homograph`, `false_friend`, ISO 19135 register management types, etc.) are expressed as `gloss:` properties in the Glossarist OWL ontology and serialized as-is in TBX output using the corresponding TBX data category.
 
 ## Design Principles
 
-1. **MECE coverage** — The relationship types form a mutually exclusive, collectively exhaustive set covering all ISO 10241-1, ISO 25964, SKOS, ISO 12620, and TBX relationship categories
+1. **MECE coverage** — The relationship types form a mutually exclusive, collectively exhaustive set covering all ISO 10241-1, ISO 19135, ISO 25964, SKOS, ISO 12620, and TBX relationship categories
 2. **No overlap with SKOS** — Where SKOS defines a property, Glossarist reuses the exact same semantics (e.g., `broader` = `skos:broader`)
 3. **Directional** — Every relationship has a source and target; inverse pairs are separate types (`broader`/`narrower`, `supersedes`/`superseded_by`)
 4. **Typed hierarchy** — The three ISO 25964 hierarchy types (generic, partitive, instantial) are distinct because they carry different semantic meaning and affect how concept trees are rendered
+5. **Cross-dataset by design** — Relationships use URN-based references that span datasets, enabling multi-edition and cross-vocabulary navigation
 
 See the [YAML Schema Reference](/reference/schema-browser) for the JSON Schema definition of the RelatedConcept entity, the [Entity Field Reference](/reference/entity-fields) for field-level details, and the [Standards compliance reference](/docs/standards) for ISO standard mappings.

--- a/docs/model/schemas/index.md
+++ b/docs/model/schemas/index.md
@@ -32,7 +32,7 @@ Each schema feature is demonstrated with standalone YAML examples in the concept
 | 03 | Pronunciation | IPA, Hepburn romanization, script cascade |
 | 04 | Definition, notes, examples | DetailedDefinition with per-item sources |
 | 05 | Domains | Classification and subject area references |
-| 06 | Relationships | All 32 typed semantic relationship types |
+| 06 | Relationships | All 52 typed semantic relationship types |
 | 07 | Sources & citations | All 10 source statuses, locality, custom locality |
 | 08 | Multi-language | Four scripts (Latn, Arab, Hani, Cyrl) in one concept |
 | 09 | Non-verbal representations | Images, tables, formulas |
@@ -42,6 +42,8 @@ Each schema feature is demonstrated with standalone YAML examples in the concept
 | 13 | Superseded & deprecated | Full deprecation lifecycle |
 | 14 | Term types | All 34 ISO 12620 term type values |
 | 15 | Citation features | Locality ranges, custom locality, links |
+| 16 | Tags | Organizational metadata vs terminological domains |
+| 17 | Dataset register | URN resolution, cross-dataset supersession |
 
 - [V3 examples (GitHub)](https://github.com/glossarist/concept-model/tree/main/schemas/v3/examples)
 - [V2 examples (GitHub)](https://github.com/glossarist/concept-model/tree/main/schemas/v2/examples)


### PR DESCRIPTION
Updates glossarist.org documentation to reflect concept-model PR glossarist/concept-model#51.

## Changes

### DesignationRelationship docs
- `docs/model/designations.md`: new "Designation Relationships" section documenting the `DesignationRelationship` model (`type`, `content`, `target`), distinct from concept-level `RelatedConcept`
- `docs/model/relationships.md`: new "Designation-level relationships" subsection with YAML example and cross-link to designations page

### 52 relationship types
- `RelationshipTypes.vue`: categories expanded to all 52 types covering ISO 10241-1, ISO 19135, ISO 25964/SKOS, ISO 12620/TBX; inverse pairs updated
- `docs/model/relationships.md`: cross-dataset navigation, inverse derivation table, expanded SKOS alignment, ISO 19135 coverage
- `docs/model/schemas/index.md`: updated to 52 types, added examples 16-17

### Annotations
- `docs/model/concepts.md`: added `annotations` field to LocalizedConcept table

### Build data
- `public/data/taxonomies.json`, `ontology-schema.json`, `stats.json` will be regenerated by CI from the updated concept-model clone (these are gitignored and generated at build time)