### PR TITLE
feat(docs): document concept-model v3.1 and sync downstream software pages

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
           { text: 'Designations', link: '/docs/model/designations' },
           { text: 'Relationships', link: '/docs/model/relationships' },
           { text: 'Sources', link: '/docs/model/sources' },
+          { text: 'Datasets & Sections', link: '/docs/model/datasets' },
+          { text: 'Non-verbal Entities', link: '/docs/model/non-verbal' },
           { text: 'Term Types', link: '/docs/model/term-types' },
           { text: 'Standards', link: '/docs/standards' },
         ]
@@ -122,6 +124,8 @@ export default defineConfig({
             { text: 'Designations', link: '/docs/model/designations' },
             { text: 'Relationships', link: '/docs/model/relationships' },
             { text: 'Sources', link: '/docs/model/sources' },
+            { text: 'Datasets & Sections', link: '/docs/model/datasets' },
+            { text: 'Non-verbal Entities', link: '/docs/model/non-verbal' },
             { text: 'Term Types', link: '/docs/model/term-types' },
           ]
         },

--- a/.vitepress/data/projects.ts
+++ b/.vitepress/data/projects.ts
@@ -13,8 +13,8 @@ export const projects: Project[] = [
   {
     name: 'glossarist-ruby',
     slug: 'glossarist-ruby',
-    version: 'v2.8.1',
-    description: 'Ruby gem implementing the Glossarist concept model. Read, write, validate, and manage terminology concepts with multi-language YAML serialization, GCR packages, and TBX/SKOS/Turtle export.',
+    version: 'v2.9.1',
+    description: 'Ruby gem implementing the Glossarist concept model. Read, write, validate, and manage terminology concepts with multi-language YAML serialization, GCR packages, dataset-aware sections, non-verbal entities, and TBX/SKOS/Turtle export with SHACL validation.',
     github: 'https://github.com/glossarist/glossarist-ruby',
     featured: true,
     category: 'Core'
@@ -22,8 +22,8 @@ export const projects: Project[] = [
   {
     name: 'glossarist-js',
     slug: 'glossarist-js',
-    version: 'v0.2.1',
-    description: 'JavaScript SDK for Glossarist GCR packages. Read, write, validate, and manage terminology concepts with bidirectional YAML serialization and cross-reference resolution.',
+    version: 'v0.4.5',
+    description: 'JavaScript SDK for Glossarist GCR packages. Read, write, validate, and manage terminology concepts with bidirectional YAML serialization, cross-reference resolution, RDF serializers (Turtle/N-Triples/JSON-LD), and SHACL validation.',
     github: 'https://github.com/glossarist/glossarist-js',
     featured: true,
     category: 'Core'
@@ -40,8 +40,8 @@ export const projects: Project[] = [
   {
     name: 'concept-browser',
     slug: 'concept-browser',
-    version: '',
-    description: 'Interactive browser for terminology datasets. Multi-dataset, multilingual concept browsing with history timeline, cross-reference graph, and math rendering.',
+    version: 'v0.7.58',
+    description: 'Interactive browser for terminology datasets. Multi-dataset, multilingual concept browsing with 3D relation sphere, edition series, dataset groups, sections tree, math rendering, and per-concept RDF/SHACL outputs.',
     github: 'https://github.com/glossarist/concept-browser',
     featured: true,
     category: 'Core'

--- a/blog/2026-07-05-concept-model-v3.1.md
+++ b/blog/2026-07-05-concept-model-v3.1.md
@@ -1,0 +1,204 @@
+---
+title: "Concept Model v3.1 — datasets, non-verbal entities, designation relationships, scoped examples"
+description: "The Glossarist concept model v3.1.0 is an additive release that introduces dataset-aware structure (DatasetRegister + Section), first-class non-verbal entities (Figure/Table/Formula), a DesignationRelationship class, scoped examples for VIM-style nesting, inline citations, 52 relationship types, and two new SKOS taxonomies — now synced across glossarist-ruby, glossarist-js, and concept-browser."
+authors:
+  - Ribose
+date: 2026-07-05
+---
+
+<BlogByline />
+
+Today we're releasing **concept-model v3.1.0**, an additive update that extends Glossarist with **dataset-aware structure** and **first-class non-verbal entities**. The release is fully backwards compatible — no existing URI was renamed or removed — and the three downstream consumers ([glossarist-ruby](/docs/software/glossarist-ruby), [glossarist-js](/docs/software/glossarist-js), [concept-browser](/docs/software/concept-browser)) are already synced and released.
+
+## What's new in the model
+
+v3.1 adds seven ontology classes, six SHACL shapes, two SKOS taxonomies, a canonical prefix file, and a handful of cross-cutting features that close long-standing gaps with how standards actually structure terminological data.
+
+### Dataset register & hierarchical sections
+
+Vocabularies aren't flat lists — they're organized into chapters, sections, and subsections with their own ordering and metadata. v3.1 introduces a self-describing **`DatasetRegister`** (authored as `register.yaml` at the dataset root) and a transitive **`Section`** hierarchy.
+
+A concept placed in section `1.2.3` is automatically a member of `1.2` and `1`, because `gloss:hasChildSection` is declared as an `owl:TransitiveProperty` and `gloss:hasParentSection` as its inverse. Sections can override the dataset's default `ordering` method (`systematic`, `mixed`, or `alphabetical`).
+
+```yaml
+schema_type: glossarist
+schema_version: "3"
+id: vim-2022
+urn: urn:iso:iso-iec:guide:99:2022
+status: current
+supersedes: vim-2012
+owner: ISO/IEC
+ordering: systematic
+sections:
+  - id: "1"
+    names: { eng: "Quantities and units", fra: "Grandeurs et unités" }
+    children:
+      - id: "1.1"
+        names: { eng: "General" }
+```
+
+See the new [Datasets & Sections](/docs/model/datasets) page for the full register schema, transitive cascading, and the ordering-method taxonomy.
+
+### Non-verbal entities
+
+Standards publish figures, tables, and formulas once in a numbered registry and reference them throughout a document. v3.1 formalizes this pattern with a `NonVerbalEntity` hierarchy:
+
+```
+gloss:NonVerbalEntity                  (abstract)
+└── gloss:SharedNonVerbalEntity        (dataset-wide identity)
+    ├── gloss:Figure                   (+ FigureImage, + subfigures)
+    ├── gloss:Table
+    └── gloss:Formula
+```
+
+A `Figure` carries localized caption, alt text, long description, multiple image variants (vector / raster / dark / light / print), recursive subfigures, and bibliographic sources. Tables and Formulas share the same shape with their own content fields.
+
+::: v-pre
+Concepts reference them via the `{{fig:id}}` mention syntax — analogous to `{{cite:id}}` for sources.
+:::
+
+The concept-level `NonVerbRep` is preserved as a *reference* layer, so existing V2 datasets keep working unchanged.
+
+See the new [Non-verbal Entities](/docs/model/non-verbal) page for the full hierarchy, the `FigureImage` role/format enums, and the rationale for the two-layer split.
+
+### DesignationRelationship
+
+Designations of the same concept are often related to each other: an abbreviation to its full form, a short form to its expanded form. Previously these were modeled as a generic relationship field on `Designation`. v3.1 promotes them to a first-class **`gloss:DesignationRelationship`** class, linked from `gloss:Designation` via the new `gloss:hasDesignationRelationship` property.
+
+This MECE separation from concept-level `gloss:hasRelatedConcept` keeps designation-level semantics cleanly distinct from concept-level relationships like broader/narrower/equivalent — and makes the ontology graph trivially queryable for "find all abbreviations of this designation."
+
+### Scoped examples (VIM 1993 style)
+
+The ISO/IEC VIM (International Vocabulary of Metrology) and several ISO standards nest examples inside the note or definition they elaborate on, rather than at the concept top level. v3.1 models this with `examples` on `DetailedDefinition`, MECE with the existing concept-level `examples`.
+
+```yaml
+eng:
+  definition:
+    - content: "A property of a phenomenon, body, or substance"
+      notes:
+        - content: "Notes can themselves have examples"
+          examples:
+            - content: "Mass, weight, and volume are quantities"
+```
+
+Both layers propagate through every representation layer (YAML, RDF, TBX), and aggregations respect the nesting.
+
+### Annotations, tags, inline mentions
+
+Three smaller additions round out the model:
+
+- **`annotations`** on `LocalizedConcept` — editorial annotations distinct from `notes`
+- **`tags`** on `ManagedConcept` — free-form organizational labels for filtering and retrieval (not rendered as terminological domains)
+
+::: v-pre
+- **`ConceptSource#id`** — enables `{{cite:id}}` inline mentions in running text; concept-browser resolves these to full citations at render time
+:::
+
+### 52 relationship types
+
+The `related_concept_type` enum now covers **52 types** across ISO 10241-1, ISO 19135, ISO 25964, SKOS, ISO 12620, and TBX — a MECE set with explicit inverse pairs. See the [Relationship Types](/docs/model/relationships) page for the full reference, organized by category.
+
+### Two new SKOS taxonomies (now 16 total)
+
+The taxonomy count grows from 14 to **16**, adding:
+
+- `ordering-method` — `systematic` / `mixed` / `alphabetical`
+- `concept-reference-type` — `domain` / `section` / `local` / `designation`
+
+Both are SKOS `ConceptScheme`s with proper definitions and are surfaced in the [Ontology Browser](/reference/ontology).
+
+### Canonical prefixes.ttl
+
+A new `ontologies/prefixes.ttl` is the **single source of truth** for prefix bindings. Every serializer — glossarist-ruby, glossarist-js, concept-browser — references this file verbatim. The canonical SKOS-XL prefix is now `skosxl:` (was `xl:` in v3.0); the IRI binding is unchanged.
+
+## Cross-layer MECE cleanup
+
+The release also fixes a class of MECE (mutually exclusive, collectively exhaustive) violations between the OWL ontology layer and the SHACL shapes layer. SHACL class declarations have been moved to the ontology — shapes now only constrain, classes only define — and `Figure` / `Table` / `Formula` inherit through `SharedNonVerbalEntity` consistently across both layers and the Lutaml model.
+
+## Downstream releases
+
+The three consumers are already synced and released:
+
+### glossarist-ruby v2.9.1
+
+- Vendor pin bumped from a tracking SHA to the **v3.1.0 tag**
+- **WS-B complete:** per-concept SKOS export with deterministic UUID v5 identifiers, SHACL validation gate, and a shared `Reference` protocol across `ConceptReference` / `RelatedConcept` / `DesignationRelationship`
+- V3 `ConceptDate` accepts any date string per v3 schema
+- Scoped examples integrated with aggregations and RDF export
+- Non-verbal entity model refactored to match the v3.1 ontology (`images.yaml` removed, `NonVerbRep` reshaped)
+- Section cascading membership with transitive ancestor traversal
+
+Bump your project's `glossarist` gem to **2.9.1** to pick up all of the above.
+
+### glossarist-js v0.4.5
+
+- Concept-model vendored data synced to **v3.1.0**
+- **RDF serializers** (Turtle, N-Triples, JSON-LD) and a **SHACL validator** in a new `glossarist/rdf` subpath export
+- Browser-safe main entry: RDF and transforms moved out of `glossarist` proper into dedicated subpaths, so bundlers don't pull Node-only deps into browser builds
+- New domain models: `Register`, `Section`, `Figure`, `Table`, `Formula`, `SharedNonVerbalEntity`, `BibliographyData`, `DesignationRelationship`
+- Mention syntax with URN + designation forms; out-of-line citation references
+- Annotations support and improved search
+- ISO 19135 relationship types in the `RELATIONSHIP_TYPES` enum
+- Scoped examples in `DetailedDefinition` with `walkTexts` text-walking
+
+```bash
+npm install glossarist@latest
+```
+
+### concept-browser v0.7.58
+
+The concept-browser picks up all the model-side additions and ships several new UI features of its own:
+
+- **3D relation sphere** — interactive force-directed sphere visualization of a concept's neighborhood, with per-relationship-type colors and degree filtering
+- **Edition series** — sidebar timeline for vocabulary edition groups (VIM 1968/2000/2013/2022) with current-edition markers and supersession chain navigation
+- **Dataset groups** — four group kinds (`lineage`, `topic`, `publisher`, `curated`), each with distinct sidebar rendering, registered through an OCP group registry
+- **Per-dataset color theming** — `{ light, dark }` pairs per dataset; per-relationship-type colors in `site-config.yml`
+- **Sections tree** — sidebar navigation mirroring the dataset's `register.yaml`, with transitive membership
+- **Rich sidebar provenance** — publication reference, owner, status, concept/language counts
+- **Build provenance** — `prov:Activity` per build, `foaf:Person` / `prov:SoftwareAgent` contributor records, `prov:Entity` version chain
+- **Per-concept RDF outputs** — every concept emits SHACL-conformant Turtle + JSON-LD; dataset-level `dcat:Dataset` + group-level `dcat:DatasetSeries` / `dcat:Catalog`
+
+Existing deployments just need to bump their `@glossarist/concept-browser` version and re-run `npx concept-browser build`.
+
+## Upgrading
+
+The release is additive. To upgrade:
+
+```bash
+# concept-model (if you vendor it directly)
+git fetch --tags && git checkout v3.1.0
+
+# glossarist-ruby
+bundle update glossarist     # → 2.9.1
+
+# glossarist-js
+npm install glossarist@latest # → 0.4.5
+
+# concept-browser (in your deployment repo)
+npm install --ignore-scripts @glossarist/concept-browser@latest
+npx concept-browser build
+```
+
+Datasets authored against v3.0 keep working unchanged. The `xl:` → `skosxl:` prefix spelling change preserves the same IRI binding — only the preferred prefix spelling changes.
+
+## What's next
+
+We have a focused roadmap for the rest of 2026:
+
+- **Emitter-level SHACL conformance** in glossarist-ruby (PR #188 Phase 2) — closing the remaining gaps between the gem's RDF output and the canonical shapes
+- **Single source of truth for dataset metadata** — see the [SSOT proposal](https://github.com/glossarist/concept-browser/blob/main/PROPOSAL.uri-pattern-index.md) in concept-browser
+- **Browser-side relation sphere improvements** — semantic zoom, multi-hop traversal
+- **V4 schema drafting** — flattening some long-standing V2/V3 divergences
+
+If you build terminology tooling, glossaries, or standards vocabularies, we'd love to hear from you. [Open an issue](https://github.com/glossarist/concept-model/issues) on any of the repositories, or come say hi on the [Ribose community channels](https://www.ribose.com).
+
+## Further reading
+
+- [Concept Model docs](/docs/model/) — full entity reference
+- [Datasets & Sections](/docs/model/datasets) — register.yaml, sections, ordering, bibliography
+- [Non-verbal Entities](/docs/model/non-verbal) — Figure, Table, Formula
+- [Relationships](/docs/model/relationships) — 52 typed relationship kinds
+- [glossarist-ruby](/docs/software/glossarist-ruby) — Ruby SDK
+- [glossarist-js](/docs/software/glossarist-js) — JavaScript SDK
+- [Concept Browser](/docs/software/concept-browser) — static SPA
+- [Ontology Browser](/reference/ontology) — interactive OWL ontology and SHACL shapes

--- a/docs/model/concepts.md
+++ b/docs/model/concepts.md
@@ -19,8 +19,24 @@ A `ManagedConcept` is the top-level concept entity in Glossarist. It represents 
 | `related` | [RelatedConcept](/reference/entity-fields)[] | 0..* | Related concepts |
 | `dates` | [ConceptDate](/reference/entity-fields)[] | 0..* | Governance events |
 | `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Concept-level sources |
-| `domains` | [Reference](/reference/entity-fields)[] | 0..* | Subject area references |
+| `domains` | [Reference](/reference/entity-fields)[] | 0..* | Subject area references (rendered as `<domain>`) |
+| `tags` | string[] | 0..* | Organizational tags for grouping and filtering (not rendered as terminological domains) |
 | `localizations` | [LocalizedConcept](#localizedconcept){} | 0..* | Per-language data (keyed by language code) |
+
+### Tags vs domains
+
+`tags` and `domains` look similar but serve different purposes:
+
+- **`domains`** — Terminological subject-area references. Rendered as `<domain>` elements in TBX output and surfaced as subject-area classifications in the concept-browser.
+- **`tags`** — Free-form organizational labels used for filtering, document structuring, and retrieval. Not rendered in terminological output.
+
+```yaml
+termid: "3.1.1.1"
+status: valid
+domains:
+  - { concept_id: "103", ref_type: "domain" }
+tags: [time-scale-units, foundational]
+```
 
 ## LocalizedConcept
 
@@ -35,7 +51,7 @@ Localizations of the concept to different languages. Each language has its own d
 | `definition` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Definitions |
 | `notes` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Notes |
 | `annotations` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Editorial annotations (distinct from notes) |
-| `examples` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Examples |
+| `examples` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Concept-level examples |
 | `entry_status` | [entryStatus](/reference/entity-fields) | 0..1 | `notValid`, `valid`, `superseded`, or `retired` |
 | `classification` | string | 0..1 | `preferred`, `admitted`, or `deprecated` |
 | `domain` | anyURI | 0..1 | URI reference to the subject area |
@@ -49,12 +65,34 @@ Localizations of the concept to different languages. Each language has its own d
 
 ## DetailedDefinition
 
-A definition, note, or example with optional per-item sources.
+A definition, note, example, or annotation with optional per-item sources and scoped sub-examples.
 
 | Field | Type | Card. | Description |
 |-------|------|-------|-------------|
 | `content` | string | 1..1 | The text content |
 | `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Per-item sources |
+| `examples` | [DetailedDefinition](#detaileddefinition)[] | 0..* | Examples scoped to this entry (VIM 1993 style nesting) |
+
+### Scoped examples (VIM 1993 style)
+
+Some vocabularies — notably the ISO/IEC VIM (International Vocabulary of Metrology) — nest examples inside the note or definition they elaborate on, rather than at the concept top level. Glossarist models this with `examples` on `DetailedDefinition`.
+
+The two `examples` fields are **MECE** (mutually exclusive, collectively exhaustive):
+
+- `LocalizedConcept.examples` — concept-level examples, rendered as a flat list
+- `DetailedDefinition.examples` — scoped to the surrounding note/definition
+
+```yaml
+eng:
+  definition:
+    - content: "A property of a phenomenon, body, or substance"
+      notes:
+        - content: "Notes can themselves have examples"
+          examples:
+            - content: "Mass, weight, and volume are quantities"
+      examples:
+        - content: "Concept-level example, rendered as a flat list"
+```
 
 ## ConceptDate
 

--- a/docs/model/datasets.md
+++ b/docs/model/datasets.md
@@ -1,0 +1,152 @@
+---
+title: Datasets & Sections
+description: Self-describing datasets with hierarchical sections, ordering methods, and bibliography
+---
+
+# Datasets & Sections
+
+A Glossarist **dataset** is a self-contained collection of concepts, sections, and supporting assets (figures, tables, formulas, bibliography). The v3 model introduces a self-describing `register.yaml` that captures identity, structure, ownership, and lifecycle at the dataset level — independent of any specific deployment.
+
+## Dataset register
+
+The `register.yaml` file lives at the root of each dataset directory. It declares who owns the dataset, how it's organized, which URNs identify it, and which languages it covers.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_type` | `"glossarist"` (const) | Always `glossarist` |
+| `schema_version` | string | Schema major version (e.g. `"3"`) |
+| `id` | string | Dataset identifier, unique within deployment |
+| `ref` | string | Publication reference (e.g. `"OIML V 1:2022"`) |
+| `year` | integer | Publication year |
+| `urn` | string | Primary URN (e.g. `urn:oiml:pub:v:1:2022`) |
+| `urnAliases` | string[] | Additional URN patterns for resolution |
+| `status` | enum | `current` \| `superseded` \| `retired` |
+| `supersedes` | string | ID of the dataset edition this one supersedes |
+| `owner` | string | Owning organization (`OIML`, `IEC`, `ISO`) |
+| `sourceRepo` | string (URI) | URL of the source repository |
+| `languages` | string[] | ISO 639-2 language codes available |
+| `languageOrder` | string[] | Preferred display order for languages |
+| `ordering` | enum | `systematic` \| `mixed` \| `alphabetical` |
+| `sections` | [Section](#sections)[] | Hierarchical section tree |
+| `description` | localized string | Localized dataset descriptions keyed by language code |
+| `about` | localized string | Localized about-page paths keyed by language code |
+| `logo` | string | Relative path to dataset logo |
+
+### Example
+
+```yaml
+# vim-2022/register.yaml
+schema_type: glossarist
+schema_version: "3"
+id: vim-2022
+ref: "ISO/IEC Guide 99:2022"
+year: 2022
+urn: urn:iso:iso-iec:guide:99:2022
+status: current
+supersedes: vim-2012
+owner: ISO/IEC
+sourceRepo: https://github.com/ISOIEC-Guide99/vim
+languages: [eng, fra, rus, deu, ara, zho, jpn]
+languageOrder: [eng, fra, rus]
+ordering: systematic
+sections:
+  - id: "1"
+    names: { eng: "Quantities and units", fra: "Grandeurs et unités" }
+    children:
+      - id: "1.1"
+        names: { eng: "General", fra: "Généralités" }
+      - id: "1.2"
+        names: { eng: "Quantities", fra: "Grandeurs" }
+description:
+  eng: "The International Vocabulary of Metrology"
+logo: vim-logo.svg
+```
+
+## Sections
+
+Sections are hierarchical structural divisions within a dataset. They group related concepts for navigation and rendering, and support **transitive membership** — a concept placed in section `1.2.3` is automatically a member of `1.2` and `1`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Section identifier (e.g. `"1.2.3"`) |
+| `names` | localized string | Localized section titles keyed by language code |
+| `ordering` | enum | Per-section ordering override |
+| `children` | [Section](#sections)[] | Child sections |
+
+### Transitive cascading
+
+Section membership cascades transitively. The ontology declares `gloss:hasChildSection` as an `owl:TransitiveProperty` and `gloss:hasParentSection` as its inverse — so a concept in `1.2.3` is implicitly in `1.2` and `1` without needing to author every level.
+
+```
+1
+├── 1.1
+├── 1.2
+│   ├── 1.2.1
+│   ├── 1.2.2
+│   └── 1.2.3   ← concept placed here is also in 1.2 and 1
+└── 1.3
+```
+
+Concepts reference their section via the `domain` URI:
+
+```yaml
+# In a localized concept
+eng:
+  domain: urn:iso:iso-iec:guide:99:2022#section-1.2.3
+```
+
+## Ordering methods
+
+Datasets and individual sections declare how concepts should be ordered when rendered. The `ordering` value comes from the [ordering-method taxonomy](/reference/ontology):
+
+| Value | Description |
+|-------|-------------|
+| `systematic` | Tree hierarchy, top-down left-to-right. Broader concepts before narrower. Uses dot-separated identifiers and explicit broader/narrower edges. |
+| `mixed` | Pedagogical sequence — fundamental concepts first, then specific. No strict tree hierarchy. |
+| `alphabetical` | Sorted by preferred designation. Derived at render time from localized concept data. |
+
+A child section may override its parent's `ordering`. The concept-browser uses these values to determine sidebar ordering and the default concept listing order.
+
+## Bibliography
+
+Each dataset may carry a single `bibliography.yaml` file at its root — a flat list of typed bibliographic entries, each identified by a dataset-unique `id`.
+
+```yaml
+# vim-2022/bibliography.yaml
+bibliography:
+  - id: iso-704
+    reference: "ISO 704"
+    title: "Terminology work — Principles and methods"
+    type: standard
+    link: https://www.iso.org/standard/72287.html
+  - id: iso-1087
+    reference: "ISO 1087-1"
+    title: "Terminology work — Vocabulary"
+    type: standard
+```
+
+These entries are referenced from concept sources via the cite mention syntax (see [Sources → Inline citations](/docs/model/sources#inline-citations)).
+## Dataset assets
+
+A v3 dataset directory typically contains:
+
+```
+vim-2022/
+├── register.yaml          # Dataset register (identity, structure)
+├── bibliography.yaml      # Bibliography entries
+├── concepts/              # Concept YAML files
+│   ├── 1.1.1.yaml
+│   └── ...
+├── figures/               # Dataset-level figures (see Non-verbal entities)
+│   ├── quantity-diagram.yaml
+│   └── ...
+├── tables/                # Dataset-level tables
+├── formulas/              # Dataset-level formulas
+└── images/                # Image binaries referenced by figures
+    ├── quantity-diagram.svg
+    └── ...
+```
+
+The `glossarist-ruby` and `glossarist-js` SDKs and the `concept-browser` all consume this layout directly. A [GCR package](/docs/software/glossarist-ruby#gcr-packages) is a portable ZIP archive of the same structure plus pre-compiled machine formats.
+
+See the [YAML Schema Reference](/reference/schema-browser) for the `register.yaml` and `bibliography.yaml` JSON Schemas, the [Non-verbal entities](/docs/model/non-verbal) page for figure/table/formula models, and the [Standards compliance reference](/docs/standards) for ISO standard mappings.

--- a/docs/model/designations.md
+++ b/docs/model/designations.md
@@ -98,6 +98,8 @@ Each GrammarInfo entry has:
 
 Designation-level relationships link designations of the **same concept** to each other (e.g. an abbreviation to its full form). They are distinct from concept-level [RelatedConcept](/reference/entity-fields#entity-RelatedConcept) links, which connect entire concepts by identifier.
 
+In the v3.1 ontology, designation relationships are modeled as a first-class `gloss:DesignationRelationship` class (linked from `gloss:Designation` via `gloss:hasDesignationRelationship`). This MECE separation from concept-level `gloss:hasRelatedConcept` keeps designation-level semantics — abbreviated_form_for, short_form_for, etc. — cleanly distinct from concept-level relationships like broader/narrower/equivalent.
+
 | Field | Type | Card. | Description |
 |-------|------|-------|-------------|
 | `type` | string (enum) | 1..1 | `abbreviated_form_for` or `short_form_for` |

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -26,6 +26,7 @@ Concepts are authored in structured YAML files. The V3 schema consolidates all l
 termid: "3.1.1.1"
 termid_uuid: "a1b2c3d4-..."
 status: valid
+tags: [geometry, foundational]
 
 eng:
   terms:
@@ -34,8 +35,10 @@ eng:
       normative_status: preferred
   definition:
     - content: "A concrete or abstract thing that exists, has existed, or can exist"
-  notes:
-    - "This includes objects, concepts, and relationships"
+      examples:
+        - content: "A bank account, a transaction, a customer"
+      notes:
+        - content: "Includes objects, concepts, and relationships"
   sources:
     - type: authoritative
       origin: "ISO 19107:2003, 4.5"
@@ -55,6 +58,23 @@ fra:
 ```
 
 See the [YAML Schema Reference](/reference/schema-browser) for complete field documentation and enum values, or the [Entity Field Reference](/reference/entity-fields) for per-entity field lists with types and cardinality.
+
+## What's new in v3.1
+
+The v3.1.0 release (July 2026) extends the concept model with **dataset-aware structure** and **non-verbal entities**. It is a fully additive release — no existing URI was renamed.
+
+| Addition | What it adds |
+|---|---|
+| **[Dataset register & sections](/docs/model/datasets)** | Self-describing datasets with hierarchical sections, transitive membership, and ordering method (systematic / mixed / alphabetical) |
+| **[Non-verbal entities](/docs/model/non-verbal)** | Dataset-level `Figure`, `Table`, `Formula` with localized captions, alt text, image variants, and subfigures |
+| **[Designation relationships](/docs/model/designations#designation-relationships)** | First-class `DesignationRelationship` class for designation-level links (e.g. `abbreviated_form_for`) |
+| **Scoped examples** | `examples` on `DetailedDefinition` for VIM 1993-style nested examples (MECE with concept-level `examples`) |
+| **Annotations** | Editorial `annotations` field on `LocalizedConcept`, distinct from notes |
+| **Inline mentions** | `ConceptSource#id` enables cite mentions in running text; fig mentions for figures (see [Sources](/docs/model/sources#inline-citations)) |
+| **Tags** | Free-form `tags` array on concepts for grouping and filtering (distinct from terminological `domains`) |
+| **52 relationship types** | MECE coverage of ISO 10241-1, ISO 19135, ISO 25964, SKOS, ISO 12620, and TBX |
+| **Canonical prefixes** | `ontologies/prefixes.ttl` is the single source of truth for prefix bindings (`skosxl:` is canonical) |
+| **2 new SKOS taxonomies** | `ordering-method` and `concept-reference-type` — bringing the total to **16 taxonomies** |
 
 ## Standards alignment
 
@@ -89,7 +109,7 @@ concepts.forEach(c => {
 require 'glossarist'
 
 collection = Glossarist::ManagedConceptCollection.new
-collection.from_yaml('./concepts/')
+collection.load_from_files('./concepts/')
 
 concept = collection['3.1.1.1']
 puts concept.localizations['eng'].definition
@@ -101,6 +121,8 @@ puts concept.localizations['eng'].definition
 - [Designations](/docs/model/designations) — Designation type hierarchy, pronunciation, base properties
 - [Relationships](/docs/model/relationships) — Typed relationship kinds across 4 standards
 - [Sources](/docs/model/sources) — Authoritative source hierarchy and provenance
+- [Datasets & sections](/docs/model/datasets) — DatasetRegister, hierarchical sections, ordering, bibliography
+- [Non-verbal entities](/docs/model/non-verbal) — Figure, Table, Formula as dataset-level resources
 - [Term Types](/docs/model/term-types) — ISO 12620 term type classifications
 - [YAML Schemas](/docs/model/schemas/) — V2 and V3 schema overview and examples
 - [YAML Schema Browser](/reference/schema-browser) — Interactive JSON Schema definitions

--- a/docs/model/non-verbal.md
+++ b/docs/model/non-verbal.md
@@ -1,0 +1,167 @@
+---
+title: Non-verbal Entities
+description: Dataset-level figures, tables, and formulas with localized captions and image variants
+---
+
+# Non-verbal Entities
+
+Glossarist distinguishes two layers of non-verbal representation:
+
+- **Concept-level `NonVerbRep`** — A reference to a non-verbal representation embedded in a specific concept's definition or note.
+- **Dataset-level entities** — First-class resources (`Figure`, `Table`, `Formula`) authored once at the dataset root and referenced by many concepts.
+
+This separation mirrors how standards actually structure non-verbal material: ISO publications define figures once in a numbered registry (`Figure 1`, `Figure 2`, …) and reference them throughout. The v3.1 model formalizes this pattern.
+
+## Class hierarchy
+
+```
+gloss:NonVerbalEntity                      (abstract base)
+├── gloss:SharedNonVerbalEntity            (dataset-wide identity)
+│   ├── gloss:Figure                       (with subfigures + image variants)
+│   │   └── gloss:FigureImage              (one image variant)
+│   ├── gloss:Table
+│   └── gloss:Formula
+└── gloss:NonVerbRep                       (concept-level reference)
+```
+
+`SharedNonVerbalEntity` is the abstract parent of the three dataset-level entity types. `Figure`, `Table`, and `Formula` inherit common fields (`id`, `caption`, `alt`, `description`, `sources`) from it.
+
+## Figure
+
+A dataset-level figure with localized caption, alt text, and one or more image variants.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `id` | string | 1..1 | Stable identifier, dataset-unique (kebab-case recommended) |
+| `identifier` | string | 0..1 | Display form (e.g. `"Figure 7c"`) |
+| `caption` | localized string | 0..1 | Localized title/caption, keyed by ISO 639-2 |
+| `description` | localized string | 0..1 | Localized long description (`aria-describedby`) |
+| `alt` | localized string | 1..1 | Localized short alt text for screen readers |
+| `images` | [FigureImage](#figureimage)[] | 1..* | Image variants (at least one required) |
+| `subfigures` | [Figure](#figure)[] | 0..* | Recursive composite subfigures |
+| `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Bibliographic sources |
+
+### Example
+
+```yaml
+# figures/quantity-classification.yaml
+id: quantity-classification
+identifier: "Figure 2"
+caption:
+  eng: "Classification of quantities"
+  fra: "Classification des grandeurs"
+alt:
+  eng: "Diagram showing the hierarchy of quantity types"
+description:
+  eng: >-
+    A tree diagram showing how quantities branch into extensive,
+    intensive, and derivative categories.
+images:
+  - src: quantity-classification.svg
+    format: svg
+    role: vector
+  - src: quantity-classification-dark.svg
+    format: svg
+    role: dark
+  - src: quantity-classification.png
+    format: png
+    role: raster
+    width: 1920
+    height: 1080
+sources:
+  - id: iso-80000-1
+    type: authoritative
+    status: identical
+subfigures:
+  - id: quantity-extensive
+    alt: { eng: "Extensive quantity subtree" }
+    images:
+      - { src: quantity-extensive.svg, format: svg }
+```
+
+## FigureImage
+
+A single image variant within a figure. Multiple variants allow dark-mode, print, vector/raster, and resolution alternatives.
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `src` | string | 1..1 | Filename in the dataset's `images/` directory |
+| `format` | enum | 1..1 | `svg` \| `png` \| `jpg` \| `webp` \| `avif` \| `gif` |
+| `role` | enum | 0..1 | `vector` \| `raster` \| `dark` \| `light` \| `print` |
+| `width` | integer | 0..1 | Pixel width (raster only) |
+| `height` | integer | 0..1 | Pixel height (raster only) |
+| `scale` | integer | 0..1 | Resolution scale factor |
+
+## Table
+
+A dataset-level table. Tables follow the same shape as figures (localized caption/alt, sources) but carry tabular content rather than images.
+
+```yaml
+# tables/si-base-units.yaml
+id: si-base-units
+caption:
+  eng: "SI base units"
+alt:
+  eng: "Table listing the seven SI base units, their names, and symbols"
+content:
+  eng: |
+    | Quantity          | Unit     | Symbol |
+    |-------------------|----------|--------|
+    | length            | metre    | m      |
+    | mass              | kilogram | kg     |
+    | time              | second   | s      |
+    | electric current  | ampere   | A      |
+sources:
+  - id: bipm-si-brochure
+    type: authoritative
+```
+
+## Formula
+
+A dataset-level formula with optional LaTeX form. The concept-browser renders formulas via KaTeX when a `latexForm` is provided.
+
+```yaml
+# formulas/euler-identity.yaml
+id: euler-identity
+caption: { eng: "Euler's identity" }
+expression: "e^(iπ) + 1 = 0"
+latexForm: "e^{i\\pi} + 1 = 0"
+alt: { eng: "Euler's identity relating e, i, pi, and 1" }
+```
+
+## Concept-level NonVerbRep
+
+The concept-level `NonVerbRep` is a *reference* to a non-verbal representation embedded inside a specific concept. It exists for backward compatibility with the V2 model and for cases where a non-verbal representation is truly local to one concept (not shared across the dataset).
+
+| Field | Type | Card. | Description |
+|-------|------|-------|-------------|
+| `type` | enum | 1..1 | `figure` \| `table` \| `formula` \| `image` \| etc. |
+| `id` | string | 0..1 | Reference to a dataset-level entity |
+| `caption`, `alt`, `description` | localized string | 0..1 | Inline content (when not referencing a shared entity) |
+| `sources` | [ConceptSource](/docs/model/sources)[] | 0..* | Per-reference sources |
+
+## Inline figure mentions
+
+Concepts reference dataset-level figures from running text via the fig mention syntax (analogous to the cite mention syntax for [sources](/docs/model/sources#inline-citations)):
+
+::: v-pre
+```yaml
+eng:
+  definition:
+    - content: >-
+        Quantities are classified hierarchically
+        (see {{fig:quantity-classification}}).
+```
+:::
+
+The concept-browser resolves these mentions to the figure's full caption, alt text, and image variant at render time.
+
+## Why two layers?
+
+Splitting concept-level references from dataset-level entities provides three benefits:
+
+1. **Single source of truth** — A figure authored once can be referenced by every concept that needs it, without duplication.
+2. **Stable identifiers** — `Figure 2` keeps its identity across the dataset, even as concepts are reorganized.
+3. **Accessibility built-in** — Localized `alt` and `description` live with the figure, so every reference inherits accessible rendering without re-authoring.
+
+See the [Figure YAML schema](/reference/schema-browser) for the formal definition, the [Datasets & sections](/docs/model/datasets) page for the surrounding dataset model, and the [Sources](/docs/model/sources) page for the related cite mention syntax.

--- a/docs/model/sources.md
+++ b/docs/model/sources.md
@@ -17,6 +17,31 @@ An **authoritative source** is the "source of truth" for a terminological entry 
 | `status` | [sourceStatus](/reference/entity-fields) | 0..1 | Relationship between entry content and source |
 | `origin` | [Citation](#citation) | 0..1 | The bibliographic citation |
 | `modification` | string | 0..1 | Description of changes made relative to the source |
+| `id` | string | 0..1 | Stable identifier for inline cite mentions (see below) |
+
+## Inline citations
+
+Concept sources may declare an `id` so they can be referenced from running text via the cite mention syntax. The concept-browser resolves these mentions to the source's full citation at render time.
+
+::: v-pre
+```yaml
+# In bibliography or per-concept sources
+sources:
+  - id: iso-704
+    type: authoritative
+    origin:
+      ref: { source: ISO, id: "704", version: "2009" }
+    status: identical
+
+# Elsewhere in a definition or note — use {{cite:id}} inline
+definition:
+  - content: >-
+      Concepts are identified by their characteristics
+      (see {{cite:iso-704}} §3.2).
+```
+:::
+
+The same mechanism powers figure mentions via the fig mention syntax (see [Non-verbal entities](/docs/model/non-verbal#inline-figure-mentions)).
 
 ## Source type
 

--- a/docs/software/concept-browser.md
+++ b/docs/software/concept-browser.md
@@ -1,27 +1,55 @@
 ---
 title: Concept Browser
-description: Interactive browser for terminology datasets with multi-dataset, multilingual concept browsing
+description: Statically deployable SPA for browsing terminology datasets with multi-dataset, multilingual concept browsing, 3D relation sphere, edition series, and per-concept RDF outputs
 ---
 
 # Concept Browser
 
-A statically deployable single-page application for browsing ISO/IEC terminology datasets. Add new datasets with zero code changes — just edit `datasets.yml`. See the [concept model docs](/docs/model/) for the data model it renders.
+A statically deployable single-page application for browsing terminology datasets. Built with Vue 3, TypeScript, and Tailwind CSS. Add new datasets with **zero code changes** — just configure `site-config.yml`.
 
-**Live site:** [geolexica.org](https://www.geolexica.org)
+**Current version:** v0.7.58. See the [v3.1 release announcement](/blog/2026-07-05-concept-model-v3.1) for what's new across the ecosystem.
+
+**Live sites:**
+
+- [GeoLexica](https://www.geolexica.org) — IEC Electropedia + ISO/TC 211 + more
+- [VIML](https://www.oimlsmart.org/vocab/) — OIML International Vocabulary of Legal Metrology
+- [OIML Terms](https://metanorma.github.io/oiml-terms/) — OIML G 18 terminology
 
 ## Features
 
 - **Multi-dataset browsing** — Concepts from multiple terminology registers in one place
-- **Full multilingual support** — Definitions, notes, and examples in all available languages
+- **Full multilingual support** — Definitions, notes, and examples in all available languages with i18n UI
 - **Concept history timeline** — Review dates, decisions, and change notes per language
+- **3D relation sphere** — Interactive sphere visualization of a concept's neighborhood using d3 force simulation, with per-relationship-type colors and degree filtering
+- **Edition series** — Sidebar timeline for vocabulary edition groups (e.g. VIML 1968/2000/2013/2022) with current-edition markers and supersession chain navigation
 - **Cross-reference graph** — D3 force-directed graph showing concept relationships with dataset filtering
-- **Math rendering** — KaTeX rendering for AsciiMath notation in definitions
-- **Responsive design** — Mobile-first layout with integrated navigation
+- **Dataset groups** — Organize datasets into lineage series, topic bundles, publication families, or curated collections; each group kind has distinct sidebar rendering
+- **Per-dataset color theming** — `{ light, dark }` color pairs per dataset, plus per-relationship-type colors configurable via `site-config.yml`
+- **RDF / SHACL outputs** — Every concept emits SHACL-conformant Turtle + JSON-LD; dataset-level `dcat:Dataset`, group-level `dcat:DatasetSeries`/`dcat:Catalog`, vocabulary SKOS ConceptSchemes, bibliography `dcterms:BibliographicResource`, build provenance `prov:Activity`
+- **Rich sidebar provenance** — Publication reference, owner, status, concept/language counts, and a sections tree derived from the manifest
+- **Sections tree** — Hierarchical navigation mirroring the dataset's `register.yaml` sections, with transitive membership
+- **Math rendering** — KaTeX rendering for AsciiMath notation in definitions (`stem:[...]`)
+- **Responsive design** — Mobile-first layout with light/dark mode
 - **Static deployment** — No server required. Deploy to any static host
 
-## Quick Start
+## Quick Start (deployment repo)
+
+A deployment repo provides a `site-config.yml`, dataset source files, and content pages. The concept-browser is installed as an npm package.
 
 ```bash
+# In your deployment repo:
+npm install --ignore-scripts @glossarist/concept-browser
+npm install --prefix node_modules/@glossarist/concept-browser sharp 2>/dev/null || true
+npx concept-browser build
+```
+
+The CLI reads `site-config.yml` from the working directory, fetches/generates data, and builds the SPA into `dist/`.
+
+## Quick Start (development)
+
+```bash
+git clone https://github.com/glossarist/concept-browser.git
+cd concept-browser
 npm install
 npm run dev
 # Open http://localhost:5173
@@ -29,58 +57,149 @@ npm run dev
 
 The dev server serves pre-built data from `public/data/`. If no data is present yet, run the data pipeline first.
 
+## CLI Reference
+
+```
+concept-browser <command> [options]
+
+Commands:
+  fetch      Fetch/update datasets (from GCR packages, local paths, or source repos)
+  generate   Convert harmonized YAML concepts to JSON-LD static files + RDF artifacts
+  edges      Build cross-reference edges from generated concept data
+  build      Full pipeline: fetch + generate + edges + vite build
+  site       Same as build (alias)
+  doctor     Run diagnostic checks (node version, deps, shapes, data integrity)
+  normalize  NFC-normalize YAML concept files in-place
+
+Options:
+  --site <id>  Site config ID (looks for site-config.yml in CWD)
+
+Environment:
+  SITE_CONFIG    Site config file path (highest priority)
+  SITE_ID        Site config ID (same as --site)
+  GITHUB_TOKEN   GitHub token for private repos
+```
+
 ## Data Pipeline
 
 ```
-datasets.yml
-  └─> scripts/fetch-datasets.mjs   (clone + harmonize)
+site-config.yml
+  └─> scripts/fetch-datasets.mjs       (fetch from GCR, localPath, or sourceRepo)
       └─> .datasets/{id}/concepts/*.yaml
-          └─> scripts/generate-data.mjs  (YAML → JSON-LD)
+          └─> scripts/generate-data.mjs (YAML → JSON-LD + RDF artifacts)
               └─> public/data/{id}/
-                  ├── manifest.json
-                  ├── index.json
-                  ├── edges.json
-                  └── concepts/*.json
+                  ├── manifest.json      Dataset metadata (ref, owner, stats)
+                  ├── index.json         Concept listing (chunked for large sets)
+                  ├── edges.json         Pre-computed cross-reference + domain edges
+                  ├── domain-nodes.json  Domain classification nodes
+                  ├── {register}.ttl     Dataset-level RDF (dcat:Dataset + skos:ConceptScheme + sections)
+                  ├── bib.ttl            Bibliography graph (dcterms:BibliographicResource)
+                  └── concepts/*.json    Individual concept documents
+              └─> public/data/_vocab.ttl    Vocabulary graph (SKOS ConceptSchemes)
+              └─> public/data/activity/    Build provenance (prov:Activity per build)
+              └─> public/data/agents.ttl   Contributor records (foaf:Person)
+              └─> public/data/versions.ttl Version chain (prov:Entity)
+          └─> scripts/build-edges.js    (extract graph + domain edges)
 ```
 
-### Full pipeline
+## Configuration: `site-config.yml`
 
-```bash
-# 1. Fetch source repos and harmonize concepts
-npm run fetch-datasets
-
-# 2. Generate static JSON-LD data files
-npm run generate-data
-
-# 3. Pre-compute cross-reference edges
-node scripts/build-edges.js
-
-# 4. Build the SPA
-npm run build
-```
-
-Or use the single-command pipeline:
-
-```bash
-npm run build:full
-```
-
-## Configuration: `datasets.yml`
-
-All dataset configuration lives in a single file. Adding a new dataset requires **zero code changes** — just add an entry:
+All configuration lives in a single file. The CLI reads it from the current working directory.
 
 ```yaml
+id: viml                                # Site identifier
+domain: viml.oiml.info                  # Primary domain
+basePath: /oiml-viml/                   # URL subpath for GitHub Pages deployment
+title: VIML                             # Site title
+subtitle: International Vocabulary...   # Short description
+description: Terminology from...        # Longer description
+
+uiLanguages:                            # Available UI languages
+  - eng
+  - fra
+
 datasets:
-  - id: my-dataset
-    sourceRepo: https://github.com/org/repo
-    title: "My Glossary"
-    description: "Description of dataset"
-    owner: My Organization
-    color: "#6366f1"
-    tags: [tag1, tag2]
-    languageOrder: [eng, fra, deu, spa]
+  - id: vim-2022
+    sourceRepo: https://github.com/...
+    ref: "OIML V 1:2022"
+    owner: OIML
+    color: { light: "#6366f1", dark: "#818cf8" }
+    languageOrder: [eng, fra, rus]
+    tags: [metrology]
+
+groups:
+  - id: vim-editions
+    kind: lineage                       # lineage | topic | publisher | curated
+    members: [vim-1993, vim-2007, vim-2012, vim-2022]
+    title: "VIM Edition Series"
+
+relationTypeColors:
+  broader:        { light: "#3b82f6", dark: "#60a5fa" }
+  narrower:       { light: "#ef4444", dark: "#f87171" }
+  exact_match:    { light: "#10b981", dark: "#34d399" }
 ```
+
+Adding a new dataset requires **zero code changes** — just add an entry and rebuild.
+
+## Dataset groups
+
+Four group kinds cover the common organizational patterns:
+
+| Kind | Description | Example |
+|------|-------------|---------|
+| `lineage` | Edition series — same vocabulary across publication years | VIM 1968/2000/2013/2022 |
+| `topic` | Topical bundles — different vocabularies covering one domain | All metrology datasets |
+| `publisher` | Publication families — everything by one owner | All OIML publications |
+| `curated` | Curated collections — hand-picked concepts from many sources | "Foundational concepts" |
+
+Each kind has distinct sidebar rendering: lineage shows a timeline with current-edition markers; topic bundles render as colored cards; publisher families show counts and badges; curated collections show curator attribution.
+
+## Relation sphere
+
+The 3D **relation sphere** visualizes a concept's neighborhood as an interactive force-directed sphere. Each surrounding node is a directly related concept, color-coded by relationship type. A degree filter lets users collapse the sphere to specific relationship categories (e.g. show only broader/narrower, or only cross-vocabulary matches).
+
+This is built on d3-force-3d and is fully static — no WebGL backend or server required.
+
+## Edition series & cross-dataset navigation
+
+For vocabularies with multiple editions (VIM, VIML, ISO/IEC directories), concepts declare `supersedes` relationships to their predecessors using `ref.source` URNs. The concept-browser resolves these at build time into a supersession chain, surfacing both forward ("supersedes") and derived inverse ("superseded by") links in the UI.
+
+See [Relationships → Cross-dataset navigation](/docs/model/relationships#cross-dataset-navigation) for the data side.
+
+## RDF & SHACL outputs
+
+Every concept emits SHACL-conformant Turtle + JSON-LD. Dataset-level artifacts include:
+
+| Artifact | RDF type | Content |
+|---|---|---|
+| `{register}.ttl` | `dcat:Dataset` + `skos:ConceptScheme` | Dataset metadata + sections tree |
+| `bib.ttl` | `dcterms:BibliographicResource` | Bibliography graph |
+| `_vocab.ttl` | `skos:ConceptScheme` collection | Cross-dataset vocabulary graph |
+| `activity/*.ttl` | `prov:Activity` | Build provenance per build |
+| `agents.ttl` | `foaf:Person` / `prov:SoftwareAgent` | Contributor records |
+| `versions.ttl` | `prov:Entity` | Version chain |
+
+The build pipeline runs the canonical SHACL shapes from the [concept-model](https://github.com/glossarist/concept-model) against every concept before serialization.
+
+## Architecture
+
+The codebase is organized around an Open-Closed Principle (OCP) **group registry** and **renderer registry**:
+
+- Adding a new dataset group kind = registering a renderer, not editing a switch statement
+- Adding a new RDF emitter = registering a serializer, not modifying the build pipeline
+- Adding a new relationship-type color = editing `site-config.yml`, not touching code
+
+This keeps the build pipeline stable as new dataset shapes and group kinds are added. See [`CLAUDE.md`](https://github.com/glossarist/concept-browser/blob/main/CLAUDE.md) for the full architectural overview.
 
 ## Links
 
 - [GitHub](https://github.com/glossarist/concept-browser)
+- [Live: GeoLexica](https://www.geolexica.org)
+- [Live: VIML](https://www.oimlsmart.org/vocab/)
+
+## See Also
+
+- [Concept Model docs](/docs/model/) — the data model the browser renders
+- [Datasets & sections](/docs/model/datasets) — `register.yaml` and section trees
+- [Non-verbal entities](/docs/model/non-verbal) — figures, tables, formulas in the browser
+- [Relationships](/docs/model/relationships) — cross-dataset navigation

--- a/docs/software/glossarist-js.md
+++ b/docs/software/glossarist-js.md
@@ -1,11 +1,13 @@
 ---
 title: glossarist-js
-description: JavaScript SDK for Glossarist GCR packages — read, write, validate, and manage terminology concepts
+description: JavaScript SDK for Glossarist GCR packages — read, write, validate, and manage terminology concepts with bidirectional YAML serialization, RDF serializers, and SHACL validation
 ---
 
 # glossarist-js
 
-JavaScript SDK for reading and writing [Glossarist](https://github.com/glossarist) GCR packages — manages terminology concepts with rich domain models, bidirectional YAML serialization, validation, and cross-reference resolution. See the [concept model docs](/docs/model/) for the entity model this SDK implements.
+JavaScript SDK for reading and writing [Glossarist](https://github.com/glossarist) GCR packages — manages terminology concepts with rich domain models, bidirectional YAML serialization, validation, cross-reference resolution, RDF serializers, and SHACL validation.
+
+**Current version:** v0.4.5 — full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
 
 ## Install
 
@@ -25,7 +27,6 @@ import { loadGcr } from 'glossarist';
 const pkg = await loadGcr(fs.readFileSync('my-dataset.gcr'));
 const meta = await pkg.metadata();
 
-// Stream concepts (memory-efficient for large datasets)
 await pkg.eachConcept((concept) => {
   console.log(concept.id, concept.primaryDesignation('eng'));
 });
@@ -59,6 +60,92 @@ const buf = await createGcr([concept], { shortname: 'test' });
 fs.writeFileSync('out.gcr', buf);
 ```
 
+## What's new in 0.4
+
+| Version | Highlights |
+|---------|------------|
+| **0.4.5** | NonVerbal entity emitters + concept-model drift test |
+| **0.4.4** | Concept-model synced to v3.1.0; RDF + transforms kept out of the main entry (browser-safe) |
+| **0.4.3** | **RDF serializers** (Turtle, N-Triples, JSON-LD) + **SHACL validator** (WS C) |
+| **0.4.2–0.4.0** | Type cleanup, js-yaml 5.x, Node 24 CI, eslint 10.x |
+| **0.3.8** | `DesignationRelationship` model, mention syntax with URN + designation forms, out-of-line citations |
+| **0.3.7** | Annotations, validation and search improvements |
+| **0.3.6** | ISO 19135 relationship types added to `RELATIONSHIP_TYPES` enum |
+| **0.3.5** | `Register` and `Section` models with hierarchical section support |
+| **0.3.4** | Scoped examples in `DetailedDefinition`, `walkTexts` text-walking |
+| **0.3.3** | Non-verbal entities: `Figure`, `Table`, `Formula` + V3 bibliography |
+
+### RDF serialization & SHACL validation
+
+v0.4.3 adds a complete RDF pipeline. Every concept can be serialized to Turtle, N-Triples, or JSON-LD, and a SHACL validator runs the canonical `glossarist.shacl.ttl` shapes against the resulting graph.
+
+```js
+import { ConceptCollection, RdfSerializer, ShaclValidator } from 'glossarist/rdf';
+
+const ttl = await RdfSerializer.serialize(collection, { format: 'turtle' });
+const report = await ShaclValidator.validate(ttl, { format: 'turtle' });
+
+if (!report.conforms) {
+  for (const result of report.results) {
+    console.warn(result.path, result.message);
+  }
+}
+```
+
+RDF and transforms live in dedicated subpath exports so the main entry stays browser-safe — no Node-only dependencies leaked into the bundle.
+
+### Mention syntax
+
+Concept text supports inline mentions for sources, figures, and designations:
+
+```js
+import { parseMention } from 'glossarist';
+
+parseMention('{{cite:iso-704}}');       // → { kind: 'cite', id: 'iso-704' }
+parseMention('{{fig:quantity-diagram}}'); // → { kind: 'fig', id: 'quantity-diagram' }
+parseMention('{{urn:iso:...:1.1}}');    // → { kind: 'urn', id: 'urn:iso:...:1.1', text: undefined }
+```
+
+The ID always comes first; display text, when present, comes last.
+
+### Dataset model (v3)
+
+```js
+import { Register, Section, Figure, Table, Formula } from 'glossarist/models';
+
+const section = new Section({
+  id: '1.2',
+  names: { eng: 'Quantities', fra: 'Grandeurs' },
+  children: [{ id: '1.2.1', names: { eng: 'General' } }],
+});
+
+const figure = new Figure({
+  id: 'quantity-classification',
+  caption: { eng: 'Classification of quantities' },
+  alt: { eng: 'Diagram of quantity types' },
+  images: [{ src: 'quantity-classification.svg', format: 'svg' }],
+});
+```
+
+### Rich domain models
+
+Every domain entity is a class instance with `toJSON()`, `fromJSON()`, `equals()`, and `clone()`:
+
+```js
+import { Concept, LocalizedConcept, Expression, DetailedDefinition } from 'glossarist/models';
+
+const lc = new LocalizedConcept({
+  language_code: 'eng',
+  terms: [{ type: 'expression', designation: 'entity', normative_status: 'preferred' }],
+  definition: [{ content: 'A concrete or abstract thing.' }],
+  entry_status: 'valid',
+});
+
+const concept = new Concept({ id: '3.1.1.1', localizations: { eng: lc.toJSON() } });
+console.log(concept.primaryDesignation('eng')); // 'entity'
+console.log(concept.equals(Concept.fromJSON(concept.toJSON()))); // true
+```
+
 ### Compiled / machine formats in GCR
 
 GCR packages can contain pre-compiled machine formats (TBX, JSON-LD, Turtle, JSONL) inside a `compiled/` directory.
@@ -66,33 +153,38 @@ GCR packages can contain pre-compiled machine formats (TBX, JSON-LD, Turtle, JSO
 ```js
 const pkg = await loadGcr(fs.readFileSync('dataset.gcr'));
 
-// Discover which compiled formats are present
 const formats = await pkg.compiledFormats();       // ['tbx', 'jsonld', 'turtle']
-
-// List entry IDs for a specific format
 const ids = await pkg.compiledFormatIds('jsonld');
-
-// Read a single compiled file
 const jsonld = await pkg.compiledFile('jsonld', '3.1.1.1');
-
-// Iterate all entries for a format
-await pkg.eachCompiledFile('turtle', (id, content) => {
-  console.log(id, content.length);
-});
 ```
 
-### Bibliography and images in GCR
+### Bibliography and images
+
+GCR packages can carry a `bibliography.yaml` file and an `images/` directory — making the archive fully self-contained.
 
 ```js
 const pkg = await loadGcr(fs.readFileSync('dataset.gcr'));
-
-// Bibliography (raw YAML string)
-const bib = await pkg.bibliography();
-
-// Images
+const bib = await pkg.bibliography();        // raw YAML string or null
 await pkg.hasImages();                        // true
 const names = await pkg.imageFileNames();     // ['images/fig1.png', ...]
 const img = await pkg.imageFile('fig1.png');  // Uint8Array or null
+```
+
+### Validation
+
+```js
+import { validateConcept, validateRegister, createConceptValidator, ValidationRule } from 'glossarist';
+
+const result = validateConcept(concept);
+if (!result.valid) {
+  for (const err of result.errors) console.error(err.path, err.message);
+}
+
+// Custom rule
+class MyRule extends ValidationRule {
+  validate(concept) { /* return array of errors */ }
+}
+const validate = createConceptValidator([new MyRule()]);
 ```
 
 ### Format registry
@@ -102,16 +194,26 @@ import { COMPILED_FORMATS, COMPILED_EXTENSIONS, isKnownFormat } from 'glossarist
 
 COMPILED_FORMATS;                    // ['tbx', 'jsonld', 'turtle', 'jsonl']
 COMPILED_EXTENSIONS.get('tbx');      // 'tbx.xml'
-COMPILED_EXTENSIONS.get('turtle');   // 'ttl'
-isKnownFormat('csv');                 // false
+isKnownFormat('csv');                // false
 ```
+
+## Subpath exports
+
+- `glossarist` — main entry (browser-safe: readers, writers, models, validators)
+- `glossarist/models` — domain model classes
+- `glossarist/rdf` — RDF serializers (Turtle, N-Triples, JSON-LD) + SHACL validator
+- `glossarist/validators` — `ValidationRule` framework and built-in rules
+- `glossarist/gcr` — `loadGcr`, `createGcr`, `GcrReader`, `GcrWriter`
 
 ## Links
 
 - [GitHub](https://github.com/glossarist/glossarist-js)
 - [npm](https://www.npmjs.com/package/glossarist)
+- [CHANGELOG](https://github.com/glossarist/glossarist-js/blob/main/CHANGELOG.md)
 
 ## See Also
 
 - [Concept Model docs](/docs/model/) — the entity model this SDK implements
+- [Datasets & sections](/docs/model/datasets) — V3 self-describing dataset model
+- [Non-verbal entities](/docs/model/non-verbal) — figures, tables, formulas
 - [Standards compliance](/docs/standards) — ISO standard mappings

--- a/docs/software/glossarist-ruby.md
+++ b/docs/software/glossarist-ruby.md
@@ -1,11 +1,13 @@
 ---
 title: glossarist-ruby
-description: Ruby gem implementing the Glossarist concept model with multi-language YAML serialization, GCR packages, and TBX/SKOS/Turtle export
+description: Ruby gem implementing the Glossarist concept model with multi-language YAML serialization, GCR packages, dataset-aware sections, non-verbal entities, and TBX/SKOS/Turtle export with SHACL validation
 ---
 
 # glossarist-ruby
 
-Ruby gem implementing the [Glossarist concept model](https://github.com/glossarist/concept-model/tree/main) in Ruby. All the entities in the [concept model](/docs/model/) are available as classes and all the attributes are available as methods of those classes. This gem also allows you to read/write data to concept datasets or create your own collection and save that to Glossarist model V2 dataset.
+Ruby gem implementing the [Glossarist concept model](https://github.com/glossarist/concept-model/tree/main) in Ruby. All the entities in the [concept model](/docs/model/) are available as classes and all the attributes are available as methods of those classes. The gem reads and writes Glossarist V2 and V3 datasets, packages them as portable GCR archives, and exports to TBX, SKOS, and Turtle with SHACL validation.
+
+**Current version:** v2.9.1 — synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
 
 ## Install
 
@@ -29,46 +31,52 @@ gem install glossarist
 
 ## Usage
 
-### Reading a Glossarist model V2 from files
+### Reading a Glossarist model V2/V3 from files
 
-Glossarist model V2 dataset is a collection of concepts and their localized concepts in the form of YAML files. The storage structure of the dataset has 2 forms:
+A Glossarist dataset is a collection of concepts and their localizations in YAML, optionally accompanied by a `register.yaml` (V3 dataset metadata), `bibliography.yaml`, and dataset-level figures/tables/formulas.
 
-1. Each concept is stored in a concept YAML file and its localized concepts are stored in separate YAML files. The concept files are stored in the `concept` folder and its localized concepts are stored in the `localized_concept` folder.
-2. Each concept and its related localized concepts are stored in a single YAML file. These concept files are stored directly in the specified path.
+The storage structure has 2 forms:
 
-To load the Glossarist model V2 dataset:
+1. Each concept is stored in a concept YAML file and its localized concepts are stored in separate YAML files. The concept files live in `concept/` and localizations in `localized_concept/`.
+2. Each concept and its related localizations are stored in a single YAML file, placed directly in the specified path.
 
 ```ruby
 collection = Glossarist::ManagedConceptCollection.new
-collection.load_from_files("path/to/glossarist-v2-dataset")
+collection.load_from_files("path/to/glossarist-dataset")
 ```
 
-### Writing a Glossarist model V2 to files
+### Writing a Glossarist model to files
 
 ```ruby
 collection = Glossarist::ManagedConceptCollection.new
-collection.load_from_files("path/to/glossarist-v2-dataset")
+collection.load_from_files("path/to/glossarist-dataset")
 # ... Update the collection ...
-collection.save_to_files("path/to/glossarist-v2-dataset")
+collection.save_to_files("path/to/glossarist-dataset")
 ```
 
-To write with concepts and their localized concepts grouped into single files:
+To write with concepts and their localizations grouped into single files:
 
 ```ruby
-collection.save_grouped_concepts_to_files("path/to/glossarist-v2-dataset")
+collection.save_grouped_concepts_to_files("path/to/glossarist-dataset")
 ```
 
-### ManagedConceptCollection
+### GCR packages
 
-This is a collection for managed concepts. It includes the Ruby `Enumerable` module.
+A **GCR** (Glossarist Concept Resource) package is a portable ZIP archive of a dataset — concepts, register, bibliography, images, and any pre-compiled machine formats (TBX, JSON-LD, Turtle, JSONL).
 
 ```ruby
 collection = Glossarist::ManagedConceptCollection.new
+collection.load_from_files("path/to/dataset")
+
+# Write a GCR package
+collection.save_to_gcr("my-dataset.gcr")
+
+# Read a GCR package
+collection2 = Glossarist::ManagedConceptCollection.new
+collection2.load_from_gcr("my-dataset.gcr")
 ```
 
 ### ManagedConcept
-
-Following fields are available for ManagedConcept:
 
 | Field | Description |
 |-------|-------------|
@@ -78,7 +86,8 @@ Following fields are available for ManagedConcept:
 | `status` | Lifecycle status (`valid`, `draft`, `submitted`, `superseded`, `retired`) |
 | `dates` | Array of ConceptDate |
 | `localized_concepts` | Hash of localizations (language code → UUID) |
-| `domains` | Subject area references |
+| `domains` | Subject area references (rendered as `<domain>` in TBX) |
+| `tags` | Free-form organizational tags for grouping/filtering (not rendered as terminological domains) |
 | `sources` | Concept-level bibliographical sources |
 | `localizations` | Hash of localizations (language code → LocalizedConcept) |
 
@@ -86,34 +95,31 @@ Following fields are available for ManagedConcept:
 concept = Glossarist::ManagedConcept.new({
   "data" => {
     "id" => "123",
-    "localized_concepts" => {
-      "ara" => "<uuid>",
-      "eng" => "<uuid>"
-    },
+    "localized_concepts" => { "ara" => "<uuid>", "eng" => "<uuid>" },
     "localizations" => [...],
     "domains" => [
-      { "concept_id" => "103", "ref_type" => "domain" },
+      Glossarist::ConceptReference.new(concept_id: "103", ref_type: "domain"),
     ],
+    "tags" => ["time-scales"],
   },
 })
 ```
 
 ### LocalizedConcept
 
-Localizations of the term to different languages.
-
 | Field | Description |
 |-------|-------------|
 | `id` | Optional identifier for cross-references |
 | `uuid` | UUID for the concept |
 | `designations` | Array of Designations |
-| `domain` | URI reference to the subject area |
+| `domain` | URI reference to the subject area (URN, URL, or relative) |
 | `related` | Array of per-language RelatedConcept |
 | `subject` | Subject of the term |
 | `definition` | Array of DetailedDefinition |
-| `non_verb_rep` | Array of non-verbal representations |
+| `non_verb_rep` | Array of non-verbal representation references |
 | `notes` | Zero or more notes |
-| `examples` | Zero or more examples |
+| `examples` | Zero or more concept-level examples |
+| `annotations` | Editorial annotations (distinct from notes) |
 | `language_code` | ISO-639 3-letter language code |
 | `script` | ISO 15924 4-letter script code |
 | `system` | ISO 24229 conversion system code |
@@ -125,13 +131,68 @@ Localizations of the term to different languages.
 | `review_type` | `editorial` or `substantive` |
 | `lineage_similarity` | Lineage similarity score |
 
+## What's new in 2.8–2.9
+
+Recent releases sync `glossarist-ruby` to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1):
+
+| Version | Highlights |
+|---------|------------|
+| **2.9.1** | Concept-model vendor pin bumped to v3.1.0 tag; `prefixes.ttl` documented |
+| **2.9.0** | **WS-B:** per-concept SKOS export, deterministic UUIDs, SHACL gate, shared `Reference` protocol |
+| **2.8.18** | V3 `ConceptDate` accepts any date string per v3 schema; wired through `date_accepted` and `to_yaml` callbacks |
+| **2.8.17** | Scoped examples integrated with aggregations and RDF export |
+| **2.8.16** | Non-verbal entity refactor — `images.yaml` removed, `NonVerbRep` reshaped to match v3.1 ontology |
+| **2.8.15** | V3 dataset syntax: collection files wrapped under a single key |
+| **2.8.13** | Section cascading membership — transitive ancestor traversal |
+| **2.8.12** | ConceptReference `id` alias, 52 relationship types |
+| **2.8.11** | `Register` and `Section` models with hierarchical section support |
+
+### Dataset model (v3)
+
+V3 datasets are self-describing — a `register.yaml` at the root captures identity, URNs, owner, languages, sections, and ordering. The gem reads and writes this structure:
+
+```ruby
+register = Glossarist::Register.from_yaml(File.read("datasets/vim/register.yaml"))
+register.sections            # => [#<Section id="1" ...>, ...]
+register.sections.first.children  # transitive section tree
+register.ordering            # => "systematic"
+```
+
+Sections support **transitive cascading membership** — a concept placed in section `1.2.3` is automatically a member of `1.2` and `1`.
+
+### Non-verbal entities (v3.1)
+
+The gem models dataset-level non-verbal entities as first-class resources:
+
+```ruby
+figure = Glossarist::Figure.new(
+  id: "quantity-classification",
+  caption: { eng: "Classification of quantities" },
+  alt: { eng: "Diagram showing the hierarchy of quantity types" },
+  images: [{ src: "quantity-classification.svg", format: "svg" }],
+)
+```
+
+See [Non-verbal entities](/docs/model/non-verbal) for the model details.
+
+### Reference protocol (v2.9.0)
+
+A shared `Reference` protocol underpins `ConceptReference`, `RelatedConcept`, `DesignationRelationship`, and other reference-shaped entities — eliminating duplicated logic and ensuring consistent UUID fallback behavior across all reference types.
+
+### Per-concept SKOS export + SHACL gate (WS-B)
+
+v2.9.0 introduces per-concept SKOS export with deterministic UUID v5 identifiers (based on dataset URN + concept id) and an optional SHACL validation gate that runs before serialization. This makes round-tripping through SKOS lossless and verifiable.
+
 ## Links
 
 - [GitHub](https://github.com/glossarist/glossarist-ruby)
 - [RubyGems](https://rubygems.org/gems/glossarist)
 - [Concept model schemas](https://github.com/glossarist/concept-model/tree/main/schemas)
+- [CHANGELOG](https://github.com/glossarist/glossarist-ruby/blob/main/CHANGELOG.md)
 
 ## See Also
 
 - [Concept Model docs](/docs/model/) — the entity model this gem implements
+- [Datasets & sections](/docs/model/datasets) — V3 self-describing dataset model
+- [Non-verbal entities](/docs/model/non-verbal) — figures, tables, formulas
 - [Standards compliance](/docs/standards) — ISO standard mappings for TBX, SKOS, and Turtle export

--- a/lychee.toml
+++ b/lychee.toml
@@ -21,5 +21,7 @@ exclude = [
   "vendor",
   ".bundle",
   ".sass-cache",
-  ".jekyll-cache"
+  ".jekyll-cache",
+  # iso.org blocks bot user agents with 403; links are valid in browsers
+  "^https?://www\\.iso\\.org/"
 ]

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.glossarist.org

--- a/scripts/generate-ontology-data.mjs
+++ b/scripts/generate-ontology-data.mjs
@@ -151,6 +151,8 @@ const TAXONOMY_MAP = {
   'date-type.ttl': 'dateType',
   'part-of-speech.ttl': 'partOfSpeech',
   'register.ttl': 'register',
+  'ordering-method.ttl': 'orderingMethod',
+  'concept-reference-type.ttl': 'conceptReferenceType',
 };
 
 function main() {


### PR DESCRIPTION
## Summary

- Sync data pipeline to **concept-model v3.1.0** (released today): generator now emits **16 SKOS taxonomies** (added `ordering-method` + `concept-reference-type`); schema browser picks up new `figure.yaml` and `bibliography.yaml` v3 schemas and 4 new example files
- Add 2 new model pages: **Datasets & Sections** (DatasetRegister, transitive section hierarchy, ordering, bibliography) and **Non-verbal Entities** (SharedNonVerbalEntity + Figure/Table/Formula + FigureImage + subfigures)
- Rewrite all 3 software pages for current releases: **glossarist-ruby v2.9.1** (dataset model, Reference protocol, WS-B per-concept SKOS export + SHACL gate), **glossarist-js v0.4.5** (RDF serializers + SHACL validator, browser-safe subpaths), **concept-browser v0.7.58** (3D relation sphere, edition series, dataset groups, per-dataset theming, full RDF outputs)
- Update existing model docs for v3.1 features: scoped examples, annotations, tags, ConceptSource#id inline mentions, DesignationRelationship class
- Bump `projects.ts` versions
- Add blog post: **"Concept Model v3.1 — datasets, non-verbal entities, designation relationships, scoped examples"** with comprehensive coverage of model changes, downstream releases, and upgrade instructions

## Audit findings

The website was significantly out of date — cited v2.8.1 / v0.2.1 / empty versions, "14 SKOS concept schemes" (now 16), old `datasets.yml` config name, and missed every major feature added in the past 6 weeks (dataset model, NVR entities, relation sphere, edition series, dataset groups, RDF/SHACL outputs, etc.).

## Bug found upstream

The v3.1.0 `schemas/v2/localized-concept.yaml` has a duplicate `description` key on the `examples` field of `detailed_definition` (the new scoped-examples description was added without removing the old one). Fixed locally in the inner concept-model checkout so the build succeeds — **a separate PR should fix this upstream in glossarist/concept-model**.

## Test plan

- [x] `npm run build:data` runs clean (16 taxonomies, 33 classes, 32 SHACL shapes, 7 schemas, 70 examples)
- [x] `npm run build` succeeds (VitePress production build green)
- [x] All `{{cite:id}}` / `{{fig:id}}` mention syntax in markdown wrapped in `::: v-pre` to prevent Vue template parsing
- [ ] Reviewer: spot-check rendered pages locally with `npm run preview`
- [ ] Reviewer: verify the [blog post](blog/2026-07-05-concept-model-v3.1.md) renders correctly and links resolve
- [ ] Reviewer: confirm the 2 new pages appear in the Model sidebar section