### PR TITLE
chore(software): sync versions to latest releases

### DIFF
--- a/.vitepress/data/projects.ts
+++ b/.vitepress/data/projects.ts
@@ -13,7 +13,7 @@ export const projects: Project[] = [
   {
     name: 'glossarist-ruby',
     slug: 'glossarist-ruby',
-    version: 'v2.9.1',
+    version: 'v2.10.0',
     description: 'Ruby gem implementing the Glossarist concept model. Read, write, validate, and manage terminology concepts with multi-language YAML serialization, GCR packages, dataset-aware sections, non-verbal entities, and TBX/SKOS/Turtle export with SHACL validation.',
     github: 'https://github.com/glossarist/glossarist-ruby',
     featured: true,
@@ -22,8 +22,8 @@ export const projects: Project[] = [
   {
     name: 'glossarist-js',
     slug: 'glossarist-js',
-    version: 'v0.4.5',
-    description: 'JavaScript SDK for Glossarist GCR packages. Read, write, validate, and manage terminology concepts with bidirectional YAML serialization, cross-reference resolution, RDF serializers (Turtle/N-Triples/JSON-LD), and SHACL validation.',
+    version: 'v0.4.12',
+    description: 'JavaScript SDK for Glossarist GCR packages. Read, write, validate, and manage terminology concepts with bidirectional YAML serialization, cross-reference resolution, RDF emitters for concepts/datasets/groups/vocabularies/bibliographies/provenance, and SHACL validation.',
     github: 'https://github.com/glossarist/glossarist-js',
     featured: true,
     category: 'Core'
@@ -31,7 +31,7 @@ export const projects: Project[] = [
   {
     name: 'glossarist-desktop',
     slug: 'desktop',
-    version: 'v1.6.14',
+    version: 'v1.6.40',
     description: 'Desktop viewer and editor for concept registries. Manage concepts, propose changes, and review change requests from a native app on Windows, macOS, and Linux.',
     github: 'https://github.com/glossarist/glossarist-desktop',
     featured: true,
@@ -40,7 +40,7 @@ export const projects: Project[] = [
   {
     name: 'concept-browser',
     slug: 'concept-browser',
-    version: 'v0.7.58',
+    version: 'v0.7.66',
     description: 'Interactive browser for terminology datasets. Multi-dataset, multilingual concept browsing with 3D relation sphere, edition series, dataset groups, sections tree, math rendering, and per-concept RDF/SHACL outputs.',
     github: 'https://github.com/glossarist/concept-browser',
     featured: true,

--- a/docs/software/concept-browser.md
+++ b/docs/software/concept-browser.md
@@ -7,7 +7,7 @@ description: Statically deployable SPA for browsing terminology datasets with mu
 
 A statically deployable single-page application for browsing terminology datasets. Built with Vue 3, TypeScript, and Tailwind CSS. Add new datasets with **zero code changes** — just configure `site-config.yml`.
 
-**Current version:** v0.7.58. See the [v3.1 release announcement](/blog/2026-07-05-concept-model-v3.1) for what's new across the ecosystem.
+**Current version:** v0.7.66 — see the [v3.1 release announcement](/blog/2026-07-05-concept-model-v3.1) for what's new across the ecosystem.
 
 **Live sites:**
 

--- a/docs/software/glossarist-js.md
+++ b/docs/software/glossarist-js.md
@@ -7,7 +7,7 @@ description: JavaScript SDK for Glossarist GCR packages — read, write, validat
 
 JavaScript SDK for reading and writing [Glossarist](https://github.com/glossarist) GCR packages — manages terminology concepts with rich domain models, bidirectional YAML serialization, validation, cross-reference resolution, RDF serializers, and SHACL validation.
 
-**Current version:** v0.4.5 — full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
+**Current version:** v0.4.12 — full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
 
 ## Install
 
@@ -64,6 +64,13 @@ fs.writeFileSync('out.gcr', buf);
 
 | Version | Highlights |
 |---------|------------|
+| **0.4.12** | Remove hardcoded `glossarist.org` base URI defaults — base URI is now always caller-supplied |
+| **0.4.11** | `writeTurtleSync` — synchronous Turtle writer for CLI/build scripts |
+| **0.4.10** | Fix dataset distribution blank-node serialization (`_:bXXX` not `<_:bXXX>`) |
+| **0.4.9** | Domain RDF emitters — vocabulary (SKOS ConceptSchemes), dataset (`dcat:Dataset`), group (`dcat:DatasetSeries` / `dcat:Catalog`), bibliography (`dcterms:BibliographicResource`), provenance (`prov:Activity`, `foaf:Person`); section descendant closure; relation categories reconciled with concept-browser |
+| **0.4.8** | `glossarist/rdf/prefixes` subpath export for browser-safe prefix lookup |
+| **0.4.7** | Type exports for `dataset-color` and `relation-categories` from `models/index.d.ts` |
+| **0.4.6** | Sync concept-model v3.1.0; NonVerbal RDF emitters (`Figure` / `Table` / `Formula`) |
 | **0.4.5** | NonVerbal entity emitters + concept-model drift test |
 | **0.4.4** | Concept-model synced to v3.1.0; RDF + transforms kept out of the main entry (browser-safe) |
 | **0.4.3** | **RDF serializers** (Turtle, N-Triples, JSON-LD) + **SHACL validator** (WS C) |
@@ -93,6 +100,20 @@ if (!report.conforms) {
 ```
 
 RDF and transforms live in dedicated subpath exports so the main entry stays browser-safe — no Node-only dependencies leaked into the bundle.
+
+### Domain RDF emitters (v0.4.9)
+
+Beyond per-concept serialization, v0.4.9 adds emitters for the surrounding linked-data graph: datasets, groups, vocabularies, bibliographies, and build provenance. These are what the [concept-browser](/docs/software/concept-browser) uses to produce its RDF artifacts.
+
+| Emitter | RDF type | Output |
+|---|---|---|
+| `vocabulary-emitter` | `skos:ConceptScheme` | Cross-dataset vocabulary graph |
+| `dataset-emitter` | `dcat:Dataset` + `skos:ConceptScheme` | Per-register dataset metadata + sections tree |
+| `group-emitter` | `dcat:DatasetSeries` / `dcat:Catalog` | Lineage series or topic/family/collection groupings |
+| `bibliography-emitter` | `dcterms:BibliographicResource` | Bibliography graph from `bibliography.yaml` |
+| `provenance-emitters` | `prov:Activity`, `prov:SoftwareAgent`, `foaf:Person`, `prov:Entity` | Build run, contributors, version chain |
+
+Section membership is closed downward — `section.descendants()` returns the transitive set of child sections, so a concept tagged with `1.2` is also a member of `1` and the dataset root. Relation categories are reconciled with concept-browser so both libraries agree on `broader`/`narrower`/`exact_match`/etc. coloring.
 
 ### Mention syntax
 
@@ -201,7 +222,8 @@ isKnownFormat('csv');                // false
 
 - `glossarist` — main entry (browser-safe: readers, writers, models, validators)
 - `glossarist/models` — domain model classes
-- `glossarist/rdf` — RDF serializers (Turtle, N-Triples, JSON-LD) + SHACL validator
+- `glossarist/rdf` — RDF serializers (Turtle, N-Triples, JSON-LD) + SHACL validator + domain emitters
+- `glossarist/rdf/prefixes` — browser-safe prefix lookup (canonical prefix SSOT)
 - `glossarist/validators` — `ValidationRule` framework and built-in rules
 - `glossarist/gcr` — `loadGcr`, `createGcr`, `GcrReader`, `GcrWriter`
 

--- a/docs/software/glossarist-ruby.md
+++ b/docs/software/glossarist-ruby.md
@@ -7,7 +7,7 @@ description: Ruby gem implementing the Glossarist concept model with multi-langu
 
 Ruby gem implementing the [Glossarist concept model](https://github.com/glossarist/concept-model/tree/main) in Ruby. All the entities in the [concept model](/docs/model/) are available as classes and all the attributes are available as methods of those classes. The gem reads and writes Glossarist V2 and V3 datasets, packages them as portable GCR archives, and exports to TBX, SKOS, and Turtle with SHACL validation.
 
-**Current version:** v2.9.1 — synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
+**Current version:** v2.10.0 — synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
 
 ## Install
 
@@ -131,12 +131,14 @@ concept = Glossarist::ManagedConcept.new({
 | `review_type` | `editorial` or `substantive` |
 | `lineage_similarity` | Lineage similarity score |
 
-## What's new in 2.8–2.9
+## What's new in 2.8–2.10
 
 Recent releases sync `glossarist-ruby` to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1):
 
 | Version | Highlights |
 |---------|------------|
+| **2.10.0** | **Refactor:** eliminate hand-rolled serialization, type dispatch, and redundant mapping — all (de)serialization now flows through declared `lutaml-model` mappings |
+| **2.9.2** | Concept-model vendor pin flipped from SHA to v3.1.0 tag; `prefixes.ttl` documented; explicit `require "time"` |
 | **2.9.1** | Concept-model vendor pin bumped to v3.1.0 tag; `prefixes.ttl` documented |
 | **2.9.0** | **WS-B:** per-concept SKOS export, deterministic UUIDs, SHACL gate, shared `Reference` protocol |
 | **2.8.18** | V3 `ConceptDate` accepts any date string per v3 schema; wired through `date_accepted` and `to_yaml` callbacks |
@@ -146,6 +148,10 @@ Recent releases sync `glossarist-ruby` to [concept-model v3.1.0](/blog/2026-07-0
 | **2.8.13** | Section cascading membership — transitive ancestor traversal |
 | **2.8.12** | ConceptReference `id` alias, 52 relationship types |
 | **2.8.11** | `Register` and `Section` models with hierarchical section support |
+
+### Serialization refactor (v2.10.0)
+
+v2.10.0 removes the last hand-rolled `to_h` / `from_h` pairs from the model layer. Attribute mappings now live entirely on the model classes via `lutaml-model` — wire names, renames, and shape changes are declaration-only. Adding a new wire-name mapping is a one-line `map :foo, to: :bar` instead of a new branch in a `to_h` body.
 
 ### Dataset model (v3)
 


### PR DESCRIPTION
## Summary

Syncs all four software project versions on the site to their latest releases, plus documents the substantive new features in glossarist-js and the v2.10.0 refactor in glossarist-ruby.

| Project | Old | New | Notes |
|---|---|---|---|
| glossarist-ruby | v2.9.1 | **v2.10.0** | Refactor eliminates hand-rolled serialization (all flows through lutaml-model mappings) |
| glossarist-js | v0.4.5 | **v0.4.12** | Domain RDF emitters (vocabulary, dataset, group, bibliography, provenance); glossarist/rdf/prefixes subpath; base URI fixes |
| glossarist-desktop | v1.6.14 | **v1.6.40** | 109 commits of incremental fixes (CR flow, build, deps) |
| concept-browser | v0.7.58 | **v0.7.66** | Migration to glossarist-js emitters (Phase 1 and 2); base URI bug fixes |

## What changed

- `.vitepress/data/projects.ts` — all 4 versions bumped; glossarist-js description updated to mention domain emitters
- `docs/software/concept-browser.md` — current version line
- `docs/software/glossarist-js.md` — current version; 7 new rows in "What's new in 0.4" table; new "Domain RDF emitters (v0.4.9)" subsection; glossarist/rdf/prefixes added to subpath exports
- `docs/software/glossarist-ruby.md` — current version; 2 new rows in release table (v2.9.2, v2.10.0); new "Serialization refactor (v2.10.0)" subsection
- `docs/software/desktop.md` — no change (uses dynamic `<ReleaseDownloader />`)

## Notes

- The blog post `blog/2026-07-05-concept-model-v3.1.md` retains its original version references — it is the historical announcement of which versions first supported v3.1, and the software pages now point readers to the latest releases.
- Concept-model itself has not moved past `ac33d5f` on main (v3.1.0 + duplicate-key fix). No model docs changes needed.

## Test plan

- [x] `npm run build` passes locally
- [ ] CI build + link_checker pass
- [ ] Spot-check rendered software pages
