### PR TITLE
chore(software): sync versions to latest releases (Jul 7)

### DIFF
--- a/.vitepress/data/projects.ts
+++ b/.vitepress/data/projects.ts
@@ -13,7 +13,7 @@ export const projects: Project[] = [
   {
     name: 'glossarist-ruby',
     slug: 'glossarist-ruby',
-    version: 'v2.10.0',
+    version: 'v2.10.4',
     description: 'Ruby gem implementing the Glossarist concept model. Read, write, validate, and manage terminology concepts with multi-language YAML serialization, GCR packages, dataset-aware sections, non-verbal entities, and TBX/SKOS/Turtle export with SHACL validation.',
     github: 'https://github.com/glossarist/glossarist-ruby',
     featured: true,
@@ -22,7 +22,7 @@ export const projects: Project[] = [
   {
     name: 'glossarist-js',
     slug: 'glossarist-js',
-    version: 'v0.4.12',
+    version: 'v0.4.15',
     description: 'JavaScript SDK for Glossarist GCR packages. Read, write, validate, and manage terminology concepts with bidirectional YAML serialization, cross-reference resolution, RDF emitters for concepts/datasets/groups/vocabularies/bibliographies/provenance, and SHACL validation.',
     github: 'https://github.com/glossarist/glossarist-js',
     featured: true,
@@ -40,7 +40,7 @@ export const projects: Project[] = [
   {
     name: 'concept-browser',
     slug: 'concept-browser',
-    version: 'v0.7.66',
+    version: 'v0.7.67',
     description: 'Interactive browser for terminology datasets. Multi-dataset, multilingual concept browsing with 3D relation sphere, edition series, dataset groups, sections tree, math rendering, and per-concept RDF/SHACL outputs.',
     github: 'https://github.com/glossarist/concept-browser',
     featured: true,

--- a/docs/software/concept-browser.md
+++ b/docs/software/concept-browser.md
@@ -7,7 +7,7 @@ description: Statically deployable SPA for browsing terminology datasets with mu
 
 A statically deployable single-page application for browsing terminology datasets. Built with Vue 3, TypeScript, and Tailwind CSS. Add new datasets with **zero code changes** — just configure `site-config.yml`.
 
-**Current version:** v0.7.66 — see the [v3.1 release announcement](/blog/2026-07-05-concept-model-v3.1) for what's new across the ecosystem.
+**Current version:** v0.7.67 — see the [v3.1 release announcement](/blog/2026-07-05-concept-model-v3.1) for what's new across the ecosystem.
 
 **Live sites:**
 
@@ -66,7 +66,8 @@ Commands:
   fetch      Fetch/update datasets (from GCR packages, local paths, or source repos)
   generate   Convert harmonized YAML concepts to JSON-LD static files + RDF artifacts
   edges      Build cross-reference edges from generated concept data
-  build      Full pipeline: fetch + generate + edges + vite build
+  about      Compile per-dataset and per-group about pages
+  build      Full pipeline: fetch + generate + edges + about + vite build
   site       Same as build (alias)
   doctor     Run diagnostic checks (node version, deps, shapes, data integrity)
   normalize  NFC-normalize YAML concept files in-place
@@ -190,6 +191,10 @@ The codebase is organized around an Open-Closed Principle (OCP) **group registry
 - Adding a new relationship-type color = editing `site-config.yml`, not touching code
 
 This keeps the build pipeline stable as new dataset shapes and group kinds are added. See [`CLAUDE.md`](https://github.com/glossarist/concept-browser/blob/main/CLAUDE.md) for the full architectural overview.
+
+### RDF layer lives in glossarist-js (v0.7.67)
+
+As of v0.7.67 the in-repo `src/components/concept-rdf/` layer is gone — ~2,300 LOC of duplicate emitters, writers, and graph abstractions deleted. The Vue UI now consumes [glossarist-js](/docs/software/glossarist-js) directly: `conceptToQuads` and `provenanceToQuads` for the graph, `writeTurtleSync` + canonical prefixes for CURIE-form Turtle, and `formatJsonLd` for JSON-LD. This makes glossarist-js the single source of truth for RDF emission across the ecosystem — fixes land once and propagate to every consumer.
 
 ## Links
 

--- a/docs/software/glossarist-js.md
+++ b/docs/software/glossarist-js.md
@@ -7,7 +7,7 @@ description: JavaScript SDK for Glossarist GCR packages — read, write, validat
 
 JavaScript SDK for reading and writing [Glossarist](https://github.com/glossarist) GCR packages — manages terminology concepts with rich domain models, bidirectional YAML serialization, validation, cross-reference resolution, RDF serializers, and SHACL validation.
 
-**Current version:** v0.4.12 — full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
+**Current version:** v0.4.15 — full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
 
 ## Install
 
@@ -64,6 +64,9 @@ fs.writeFileSync('out.gcr', buf);
 
 | Version | Highlights |
 |---------|------------|
+| **0.4.15** | Browser-safety split: `glossarist/rdf/shacl` extracted as its own subpath so the validator's Node-only deps can't leak into bundles that only need serialization |
+| **0.4.14** | RDF sections-builder compacts `classId` and predicates to CURIE form |
+| **0.4.13** | `Register.name` added; `BibliographyData` accepts bare-array shape; unified CURIE / blank-node ID / sections-builder / provenance-emitter refactor; `rdf-validate-shacl` 0.6 compat |
 | **0.4.12** | Remove hardcoded `glossarist.org` base URI defaults — base URI is now always caller-supplied |
 | **0.4.11** | `writeTurtleSync` — synchronous Turtle writer for CLI/build scripts |
 | **0.4.10** | Fix dataset distribution blank-node serialization (`_:bXXX` not `<_:bXXX>`) |
@@ -84,10 +87,11 @@ fs.writeFileSync('out.gcr', buf);
 
 ### RDF serialization & SHACL validation
 
-v0.4.3 adds a complete RDF pipeline. Every concept can be serialized to Turtle, N-Triples, or JSON-LD, and a SHACL validator runs the canonical `glossarist.shacl.ttl` shapes against the resulting graph.
+v0.4.3 adds a complete RDF pipeline. Every concept can be serialized to Turtle, N-Triples, or JSON-LD, and a SHACL validator runs the canonical `glossarist.shacl.ttl` shapes against the resulting graph. Since v0.4.15 the SHACL validator lives in its own `glossarist/rdf/shacl` subpath so its Node-only dependencies can't leak into browser bundles that only need serialization.
 
 ```js
-import { ConceptCollection, RdfSerializer, ShaclValidator } from 'glossarist/rdf';
+import { ConceptCollection, RdfSerializer } from 'glossarist/rdf';
+import { ShaclValidator } from 'glossarist/rdf/shacl';
 
 const ttl = await RdfSerializer.serialize(collection, { format: 'turtle' });
 const report = await ShaclValidator.validate(ttl, { format: 'turtle' });
@@ -222,8 +226,9 @@ isKnownFormat('csv');                // false
 
 - `glossarist` — main entry (browser-safe: readers, writers, models, validators)
 - `glossarist/models` — domain model classes
-- `glossarist/rdf` — RDF serializers (Turtle, N-Triples, JSON-LD) + SHACL validator + domain emitters
+- `glossarist/rdf` — RDF serializers (Turtle, N-Triples, JSON-LD) + domain emitters
 - `glossarist/rdf/prefixes` — browser-safe prefix lookup (canonical prefix SSOT)
+- `glossarist/rdf/shacl` — SHACL validator (Node-only deps; isolated since v0.4.15 so it can't leak into browser bundles)
 - `glossarist/validators` — `ValidationRule` framework and built-in rules
 - `glossarist/gcr` — `loadGcr`, `createGcr`, `GcrReader`, `GcrWriter`
 

--- a/docs/software/glossarist-ruby.md
+++ b/docs/software/glossarist-ruby.md
@@ -7,7 +7,7 @@ description: Ruby gem implementing the Glossarist concept model with multi-langu
 
 Ruby gem implementing the [Glossarist concept model](https://github.com/glossarist/concept-model/tree/main) in Ruby. All the entities in the [concept model](/docs/model/) are available as classes and all the attributes are available as methods of those classes. The gem reads and writes Glossarist V2 and V3 datasets, packages them as portable GCR archives, and exports to TBX, SKOS, and Turtle with SHACL validation.
 
-**Current version:** v2.10.0 — synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
+**Current version:** v2.10.4 — synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
 
 ## Install
 
@@ -137,6 +137,10 @@ Recent releases sync `glossarist-ruby` to [concept-model v3.1.0](/blog/2026-07-0
 
 | Version | Highlights |
 |---------|------------|
+| **2.10.4** | **Dataset-level non-verbal RDF:** emit `gloss:Figure` / `gloss:Table` / `gloss:Formula` per K1 shapes; final spec doubles replaced with real instances |
+| **2.10.3** | Test suite migrated off `double()` — validation rule specs use real model instances exclusively |
+| **2.10.2** | Coverage gap closed: focused specs for 14+10+4 validation rules that previously lacked them |
+| **2.10.1** | V3 fields preserved when loading legacy `concept/` directory layout (forwards-compatible reads) |
 | **2.10.0** | **Refactor:** eliminate hand-rolled serialization, type dispatch, and redundant mapping — all (de)serialization now flows through declared `lutaml-model` mappings |
 | **2.9.2** | Concept-model vendor pin flipped from SHA to v3.1.0 tag; `prefixes.ttl` documented; explicit `require "time"` |
 | **2.9.1** | Concept-model vendor pin bumped to v3.1.0 tag; `prefixes.ttl` documented |
@@ -152,6 +156,10 @@ Recent releases sync `glossarist-ruby` to [concept-model v3.1.0](/blog/2026-07-0
 ### Serialization refactor (v2.10.0)
 
 v2.10.0 removes the last hand-rolled `to_h` / `from_h` pairs from the model layer. Attribute mappings now live entirely on the model classes via `lutaml-model` — wire names, renames, and shape changes are declaration-only. Adding a new wire-name mapping is a one-line `map :foo, to: :bar` instead of a new branch in a `to_h` body.
+
+### Dataset-level non-verbal RDF (v2.10.4)
+
+The RDF exporter now emits dataset-level `gloss:Figure`, `gloss:Table`, and `gloss:Formula` individuals per the K1 shapes added in concept-model v3.1.0. Previously these were only emitted as concept-level `NonVerbRep` attachments; the dataset-level identity is now first-class, matching the way the model treats figures/tables/formulas as dataset-owned resources.
 
 ### Dataset model (v3)
 


### PR DESCRIPTION
## Summary

Syncs all four software project versions on the site to their latest releases and documents the substantive changes since PR #60.

| Project | Old | New | Key changes |
|---|---|---|---|
| glossarist-ruby | v2.10.0 | **v2.10.4** | K1-shape dataset-level Figure/Table/Formula emission; tests migrated off doubles to real instances; V3 fields preserved on legacy layout reads |
| glossarist-js | v0.4.12 | **v0.4.15** | `Register.name`; `BibliographyData` bare-array shape; `glossarist/rdf/shacl` extracted as its own subpath for browser safety |
| glossarist-desktop | v1.6.40 | v1.6.40 | No change |
| concept-browser | v0.7.66 | **v0.7.67** | `src/components/concept-rdf/` layer deleted (~2,300 LOC); Vue UI now consumes glossarist-js directly; about-pages step added to build pipeline |

## What changed

- `.vitepress/data/projects.ts` — three version bumps
- `docs/software/concept-browser.md` — current version; `about` added as 4th step in CLI Reference; new "RDF layer lives in glossarist-js (v0.7.67)" subsection in Architecture documenting the concept-rdf deletion
- `docs/software/glossarist-js.md` — current version; 3 new rows in "What's new in 0.4"; SHACL example updated for the new `glossarist/rdf/shacl` subpath; subpath exports list updated
- `docs/software/glossarist-ruby.md` — current version; 4 new rows in release table; new "Dataset-level non-verbal RDF (v2.10.4)" subsection

## Notes

- concept-model itself has not moved on `main` since `ac33d5f` (v3.1.0 + duplicate-key fix). All model docs from PR #59 remain accurate. No model-doc changes needed.
- The blog post `blog/2026-07-05-concept-model-v3.1.md` retains its original version references — it is the historical announcement of which versions first supported v3.1.

## Test plan

- [x] `npm run build` passes locally
- [ ] CI build + link_checker pass
- [ ] Spot-check rendered software pages
