### PR TITLE
fix(about): render LogoMerge inline via MDX import

### DIFF
--- a/src/content/pages/about.mdx
+++ b/src/content/pages/about.mdx
@@ -3,6 +3,7 @@ title: About Glossarist
 description: Open-source software for maintaining multi-language concept systems, aligned with ISO standards
 ---
 
+import LogoMerge from '../../components/LogoMerge.astro'
 
 # About Glossarist
 
@@ -28,7 +29,9 @@ The Glossarist logo is a synthesis of two writing traditions, reflecting the mul
 
 Together, these two script traditions merge into a single mark. This mirrors Glossarist's core principle: **a single concept can be expressed in many languages, yet remains one concept**. The Glossarist model serves as the single source of truth that encompasses multiple languages, each of which can be viewed separately but all of which refer back to the same underlying concept.
 
-{/* LogoMerge rendered by about page */}
+{/* LogoMerge rendered inline */}
+
+<LogoMerge />
 
 ### The Color Blobs
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,6 @@
 ---
 import { getEntry, render } from 'astro:content'
 import BaseLayout from '../layouts/BaseLayout.astro'
-import LogoMerge from '../components/LogoMerge.astro'
 
 const entry = await getEntry('pages', 'about')
 if (!entry) {
@@ -14,7 +13,6 @@ const { title, description } = entry.data
 <BaseLayout title={title} description={description}>
   <article class="prose about-page">
     <Content />
-    <LogoMerge />
   </article>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary

The LogoMerge diagram on the about page was rendered at the bottom of the content instead of inline between the "Together" paragraph and the "### The Color Blobs" section.

Root cause: `about.astro` appended `<LogoMerge />` after `<Content />`, so it appeared at the very end. The MDX migration made this worse because the placeholder comment in the MDX was inert.

Fix: import LogoMerge directly in `about.mdx` via MDX's native component support and use `<LogoMerge />` at the correct position. Remove it from `about.astro`.

## Test plan

- [x] `npm test` (214 tests pass)
- [x] `npm run build` (78 pages)
- [x] LogoMerge position verified: Together paragraph then LogoMerge then Color Blobs
