### PR TITLE
fix: load Inter web font and apply consistently across site

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,9 @@ const pageTitle = title === 'Glossarist' ? title : `${title} | Glossarist`
     <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
     <script is:inline>
       const stored = localStorage.getItem('glossarist-theme')
       const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -84,6 +84,7 @@ body {
   margin: 0;
   background: var(--g-bg);
   color: var(--g-text-1);
+  font-family: var(--g-font-base);
   font-size: 16px;
   line-height: var(--g-content-line-height);
   font-synthesis: none;


### PR DESCRIPTION
## Summary

**Root cause of "stupid looking font":** Inter was listed in the CSS font stack (`--g-font-base`, `--font-sans`) but was never actually loaded — no `@font-face`, no Google Fonts link, no self-hosted files. The browser fell back to generic `system-ui` for everything.

**Fix:**
- Added Google Fonts `<link>` for Inter (weights 400-800, `display=swap`) in BaseLayout `<head>`
- Added explicit `font-family: var(--g-font-base)` on `<body>` in base.css to prevent Tailwind preflight from stripping the cascade

## Test plan
- [x] `npm test` (214 tests pass)
- [x] `npm run build` (78 pages)
- [x] Inter loads via `fonts.googleapis.com` → `fonts.gstatic.com`
