### PR TITLE
fix: replace Inter with Space Grotesk + DM Sans

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -67,7 +67,7 @@ function parentActive(item: { items?: { link: string }[], link?: string }): bool
 ---
 
 <header class="flex items-center gap-6 px-6 py-3 border-b border-[var(--g-divider)] bg-[var(--g-bg)] sticky top-0 z-50">
-  <a href="/" class="flex items-center gap-2 font-bold text-[var(--g-text-1)] no-underline">
+  <a href="/" class="flex items-center gap-2 no-underline" style="font-family: var(--g-font-display); font-weight: 700; font-size: 1.25rem; letter-spacing: -0.03em; color: var(--g-text-1);">
     <img src="/logo-glossarist.svg" alt="Glossarist" width="32" height="32" />
     <span>Glossarist</span>
   </a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,7 +27,7 @@ const pageTitle = title === 'Glossarist' ? title : `${title} | Glossarist`
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&display=swap" rel="stylesheet" />
     <script is:inline>
       const stored = localStorage.getItem('glossarist-theme')
       const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -39,7 +39,8 @@
   --g-code-line-highlight-color: rgba(0, 0, 0, 0.05);
 
   /* Typography */
-  --g-font-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  --g-font-base: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --g-font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --g-font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   /* Layout */
@@ -94,6 +95,7 @@ body {
 /* ---------- Typography ---------- */
 h1, h2, h3, h4, h5, h6 {
   color: var(--g-text-1);
+  font-family: var(--g-font-display);
   font-weight: 600;
   letter-spacing: -0.02em;
   margin: 0 0 1rem;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -32,8 +32,10 @@
   --color-brand-strong: var(--color-teal);
   --color-brand-deep: var(--color-navy);
 
-  /* Fonts */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  /* Fonts: Space Grotesk for headings/logo (geometric, distinctive),
+     DM Sans for body (highly readable, neutral complement) */
+  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-display: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   /* Layout */


### PR DESCRIPTION
## Summary

Replaces the generic Inter font with a distinctive two-font system:

- **Space Grotesk** for the nav logo wordmark and all headings (h1-h6) — geometric, angular, techy, matches the Glossarist logo's visual language
- **DM Sans** for body text — highly readable, neutral complement

## Test plan
- [x] `npm test` (214 tests pass)
- [x] `npm run build` (78 pages)
