### PR TITLE
fix: nav hover gap, active state cleanup, sidebar trailing-slash bug

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -80,10 +80,10 @@ function parentActive(item: { items?: { link: string }[], link?: string }): bool
           <>
             <button
               class:list={[
-                'nav-dropdown-btn flex items-center gap-1 bg-transparent border-none px-3 py-1.5 cursor-pointer rounded-md text-sm font-medium transition-colors',
+                'nav-dropdown-btn flex items-center gap-1 bg-transparent border-none px-3 py-1.5 cursor-pointer rounded-md text-sm transition-colors',
                 parentOn
-                  ? 'nav-active text-brand bg-[var(--g-brand-soft)]'
-                  : 'text-[var(--g-text-1)] hover:text-brand hover:bg-[var(--g-bg-soft)]',
+                  ? 'nav-active text-brand font-semibold'
+                  : 'text-[var(--g-text-1)] font-medium hover:text-brand',
               ]}
             >
               {item.text}
@@ -91,24 +91,29 @@ function parentActive(item: { items?: { link: string }[], link?: string }): bool
                 <path d="M3 4.5L6 7.5L9 4.5"/>
               </svg>
             </button>
-            <ul class="absolute top-full left-0 mt-1 bg-[var(--g-bg)] border border-[var(--g-divider)] rounded-lg p-1.5 list-none m-0 min-w-[220px] hidden group-hover:block shadow-lg">
-              {item.items.map((sub) => {
-                const on = linkActive(sub.link)
-                return (
-                  <li class="m-0">
-                    <a
-                      href={sub.link}
-                      class:list={[
-                        'block px-3 py-1.5 rounded-md no-underline text-sm transition-colors',
-                        on
-                          ? 'nav-active text-brand font-semibold bg-[var(--g-brand-soft)]'
-                          : 'text-[var(--g-text-1)] hover:bg-[var(--g-bg-soft)] hover:text-brand',
-                      ]}
-                    >{sub.text}</a>
-                  </li>
-                )
-              })}
-            </ul>
+            {/* Wrapper with pt-2 creates a transparent hoverable bridge between
+                the button and the dropdown — prevents the menu from disappearing
+                when the mouse crosses the gap. */}
+            <div class="absolute top-full left-0 pt-2 z-50 hidden group-hover:block">
+              <ul class="bg-[var(--g-bg)] border border-[var(--g-divider)] rounded-lg p-1.5 list-none m-0 min-w-[220px] shadow-lg">
+                {item.items.map((sub) => {
+                  const on = linkActive(sub.link)
+                  return (
+                    <li class="m-0">
+                      <a
+                        href={sub.link}
+                        class:list={[
+                          'block px-3 py-1.5 rounded-md no-underline text-sm transition-colors',
+                          on
+                            ? 'nav-active text-brand font-medium'
+                            : 'text-[var(--g-text-1)] hover:bg-[var(--g-bg-soft)] hover:text-brand',
+                        ]}
+                      >{sub.text}</a>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
           </>
         ) : (
           <a
@@ -117,7 +122,7 @@ function parentActive(item: { items?: { link: string }[], link?: string }): bool
               'nav-plain-link px-3 py-1.5 text-sm rounded-md no-underline transition-colors',
               parentOn
                 ? 'nav-active text-brand font-medium'
-                : 'text-[var(--g-text-2)] hover:text-[var(--g-text-1)] hover:bg-[var(--g-bg-soft)]',
+                : 'text-[var(--g-text-2)] hover:text-[var(--g-text-1)]',
             ]}
           >{item.text}</a>
         )}

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -8,10 +8,18 @@ interface Props {
 const { pathname } = Astro.props
 const sidebar = sidebarFor(pathname)
 
+// Normalize: strip trailing slash (except root) and .html suffix for comparison
+function norm(p: string): string {
+  let n = p
+  if (n.endsWith('.html')) n = n.slice(0, -5)
+  if (n !== '/' && n.endsWith('/')) n = n.slice(0, -1)
+  return n
+}
+
 function isActive(link: string, current: string): boolean {
-  if (link === current) return true
-  if (link.endsWith('/') && current.startsWith(link)) return true
-  return false
+  const n = norm(link)
+  const c = norm(current)
+  return c === n || c.startsWith(n + '/')
 }
 ---
 <aside class="sidebar hidden md:block sticky top-16 max-h-[calc(100vh-4rem)] overflow-y-auto py-4 pr-2 pl-6 text-sm w-64 border-r border-[var(--g-divider)]" aria-label="Section navigation">
@@ -26,7 +34,7 @@ function isActive(link: string, current: string): boolean {
               class:list={[
                 'block px-2 py-1.5 rounded leading-snug no-underline',
                 isActive(item.link, pathname)
-                  ? 'text-brand font-semibold'
+                  ? 'nav-active text-brand font-semibold'
                   : 'text-[var(--g-text-1)] hover:bg-[var(--g-bg-soft)] hover:text-brand'
               ]}
             >

--- a/test/sidebar-outline.test.ts
+++ b/test/sidebar-outline.test.ts
@@ -13,16 +13,16 @@ function readOutline(html: string): string {
 }
 
 function isActiveSidebarLink(html: string, link: string): boolean {
-  // The active class combo is applied to <a> tags with the exact href.
-  // We scan the whole HTML because the sidebar extract may not include
-  // enough context to disambiguate from the nav (which uses different
-  // active classes inside <ul class="...dropdown">).
+  // Extract the sidebar <aside> to avoid false positives from nav dropdown
+  const asideMatch = html.match(/<aside[^>]*aria-label="Section navigation"[\s\S]*?<\/aside>/)
+  if (!asideMatch) return false
+  const sidebarHtml = asideMatch[0]
   const escaped = link.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  // Look inside an <li> (sidebar items) for the active class combo.
+  // Active sidebar links carry the `nav-active` class
   const re = new RegExp(
-    `<li[^>]*>\\s*<a[^>]*href="${escaped}"[^>]*class="[^"]*text-brand font-semibold`,
+    `<a[^>]*href="${escaped}"[^>]*class="[^"]*\\bnav-active\\b`,
   )
-  return re.test(html)
+  return re.test(sidebarHtml)
 }
 
 describe('Sidebar', () => {


### PR DESCRIPTION
## Summary

- **Nav hover gap fixed**: dropdown menu no longer disappears when moving the mouse from button to menu — a transparent `pt-2` padding bridge keeps `group-hover` active during the crossing
- **Active state cleanup**: removed heavy `bg-[var(--g-brand-soft)]` background blocks — active states now use only `text-brand` + font weight for a clean, consistent look
- **Sidebar trailing-slash bug fixed**: `isActive()` now normalizes paths before comparing, so `/model/concepts` (link) correctly matches `/model/concepts/` (pathname) — previously the current page was never highlighted in the sidebar

## Test plan
- [x] All 214 tests pass
- [x] `npm run build` succeeds (82 pages)