### PR TITLE
fix: exact-match sidebar items + TOC scroll spy

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -50,9 +50,14 @@ function norm(p: string): string {
 
 const current = norm(Astro.url.pathname)
 
-// A sub-link is active if current === link OR current starts with `${link}/`.
-// For directory links like `/model/`, this matches `/model/concepts`
-// but not `/docs/model-foo` (false-positive guard for sibling prefixes).
+// Exact match — used for individual dropdown items so that "Overview" is only
+// highlighted when you're actually on the overview page, not on every child.
+function linkExact(link: string): boolean {
+  return current === norm(link)
+}
+
+// Prefix match — used for dropdown parent buttons so the section is
+// highlighted when you're on any page within it.
 function linkActive(link: string): boolean {
   const n = norm(link)
   return current === n || current.startsWith(n + '/')
@@ -97,7 +102,7 @@ function parentActive(item: { items?: { link: string }[], link?: string }): bool
             <div class="absolute top-full left-0 pt-2 z-50 hidden group-hover:block">
               <ul class="bg-[var(--g-bg)] border border-[var(--g-divider)] rounded-lg p-1.5 list-none m-0 min-w-[220px] shadow-lg">
                 {item.items.map((sub) => {
-                  const on = linkActive(sub.link)
+                  const on = linkExact(sub.link)
                   return (
                     <li class="m-0">
                       <a

--- a/src/components/Outline.astro
+++ b/src/components/Outline.astro
@@ -21,10 +21,78 @@ const outline = headings.filter(h => h.depth >= 2 && h.depth <= 3)
         <li class:list={[h.depth === 3 && 'pl-3']}>
           <a
             href={`#${h.slug}`}
-            class="block py-1 px-2 text-[var(--g-text-2)] no-underline hover:text-brand leading-snug"
+            data-toc-slug={h.slug}
+            class="toc-link block py-1 px-2 text-[var(--g-text-2)] no-underline hover:text-brand leading-snug border-l-2 border-transparent transition-colors"
           >{h.text}</a>
         </li>
       ))}
     </ul>
   </aside>
 )}
+
+<style is:global>
+.toc-link.toc-active {
+  color: var(--g-brand);
+  font-weight: 500;
+  border-left-color: var(--g-brand);
+}
+</style>
+
+<script>
+  function initScrollSpy() {
+    const tocLinks = document.querySelectorAll<HTMLAnchorElement>('[data-toc-slug]')
+    if (tocLinks.length === 0) return
+
+    const headingMap = new Map<Element, HTMLAnchorElement>()
+    tocLinks.forEach(link => {
+      const slug = link.getAttribute('data-toc-slug')
+      if (!slug) return
+      const heading = document.getElementById(slug)
+      if (heading) headingMap.set(heading, link)
+    })
+    if (headingMap.size === 0) return
+
+    let currentActive: HTMLAnchorElement | null = null
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Find the topmost intersecting heading
+        let topMost: Element | null = null
+        let topMostTop = Infinity
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.boundingClientRect.top < topMostTop) {
+            topMost = entry.target
+            topMostTop = entry.boundingClientRect.top
+          }
+        }
+        if (topMost) {
+          const link = headingMap.get(topMost)
+          if (link && link !== currentActive) {
+            if (currentActive) currentActive.classList.remove('toc-active')
+            link.classList.add('toc-active')
+            currentActive = link
+          }
+        }
+      },
+      {
+        // Trigger when heading is between 80px from top (below sticky header)
+        // and 30% from top — gives a comfortable scroll spy zone
+        rootMargin: '-80px 0px -70% 0px',
+        threshold: 0,
+      },
+    )
+
+    headingMap.forEach((_, heading) => observer.observe(heading))
+
+    // Highlight the first heading on page load
+    if (!currentActive && tocLinks.length > 0) {
+      const first = tocLinks[0] as HTMLAnchorElement
+      first.classList.add('toc-active')
+      currentActive = first
+    }
+  }
+
+  // Run on initial load and on Astro view transitions (if enabled)
+  document.addEventListener('DOMContentLoaded', initScrollSpy)
+  document.addEventListener('astro:page-load', initScrollSpy)
+</script>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -16,10 +16,12 @@ function norm(p: string): string {
   return n
 }
 
+// Exact match only — the current page is highlighted, not section roots.
+// The dropdown BUTTON in the nav uses prefix matching to show which section
+// you're in; individual sidebar links use exact matching so Overview is only
+// highlighted when you're actually on the overview page.
 function isActive(link: string, current: string): boolean {
-  const n = norm(link)
-  const c = norm(current)
-  return c === n || c.startsWith(n + '/')
+  return norm(current) === norm(link)
 }
 ---
 <aside class="sidebar hidden md:block sticky top-16 max-h-[calc(100vh-4rem)] overflow-y-auto py-4 pr-2 pl-6 text-sm w-64 border-r border-[var(--g-divider)]" aria-label="Section navigation">

--- a/test/sidebar-outline.test.ts
+++ b/test/sidebar-outline.test.ts
@@ -80,11 +80,11 @@ describe('Sidebar', () => {
       expect(isActiveSidebarLink(html, '/docs/software/glossarist-ruby')).toBe(true)
     })
 
-    it('does highlight the section Overview when on a deeper page (conventional)', () => {
-      // /docs/software/ is the parent of /docs/software/glossarist-ruby —
-      // sidebar marks the section root active when you're inside it.
+    it('does NOT highlight the section Overview when on a deeper page', () => {
+      // Only the current page should be highlighted — not the section root.
+      // The dropdown BUTTON uses prefix matching; sidebar links use exact matching.
       const html = readBuilt('dist/docs/software/glossarist-ruby/index.html')
-      expect(isActiveSidebarLink(html, '/docs/software/')).toBe(true)
+      expect(isActiveSidebarLink(html, '/docs/software/')).toBe(false)
     })
 
     it('does NOT highlight a sibling section', () => {


### PR DESCRIPTION
## Summary

- **Sidebar/nav items use exact match**: "Overview" is only highlighted when you're actually on the overview page, not on every child page. The nav dropdown BUTTON still uses prefix matching so the section is highlighted when you're anywhere within it.
- **TOC scroll spy**: IntersectionObserver watches h2/h3 headings and highlights the corresponding outline entry as you scroll. Active entry gets brand color + left border indicator.

## Test plan
- [x] All 214 tests pass
- [x] `npm run build` succeeds (82 pages)