### PR TITLE
fix: ticker translations, reduced-motion hover, stats import

### DIFF
--- a/scripts/generate-ontology-schema.mjs
+++ b/scripts/generate-ontology-schema.mjs
@@ -592,6 +592,11 @@ function main() {
   };
   writeFileSync(STATS_OUTPUT, JSON.stringify(stats, null, 2) + '\n');
   console.log(`Wrote ${STATS_OUTPUT}`);
+
+  // Also write to src/data/ for static imports (Vite warns on importing from public/)
+  const STATS_SRC = resolve(ROOT, 'src', 'data', 'stats.json');
+  writeFileSync(STATS_SRC, JSON.stringify(stats, null, 2) + '\n');
+  console.log(`Wrote ${STATS_SRC}`);
 }
 
 main();

--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -1,21 +1,21 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { premierProjects } from '../data/projects'
-import stats from '../../public/data/stats.json'
+import stats from '../data/stats.json'
 
 const st = stats
 
 const activeCodeTab = ref('yaml')
 
 const langCycle = [
-  { code: 'eng', term: 'entity' },
-  { code: 'fra', term: 'entité' },
-  { code: 'deu', term: 'Entität' },
-  { code: 'spa', term: 'entidad' },
-  { code: 'zho', term: '实体' },
-  { code: 'ara', term: 'كيان' },
-  { code: 'rus', term: 'сущность' },
-  { code: 'jpn', term: 'エンティティ' },
+  { code: 'eng', term: 'many languages' },
+  { code: 'fra', term: 'plusieurs langues' },
+  { code: 'deu', term: 'viele Sprachen' },
+  { code: 'spa', term: 'muchos idiomas' },
+  { code: 'zho', term: '多种语言' },
+  { code: 'ara', term: 'لغات كثيرة' },
+  { code: 'rus', term: 'много языков' },
+  { code: 'jpn', term: '多くの言語' },
 ]
 
 // Duplicate the list for seamless infinite scroll
@@ -562,7 +562,13 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
   animation-play-state: paused;
 }
 @media (prefers-reduced-motion: reduce) {
-  .hp-ticker-track { animation: none; }
+  .hp-ticker-track {
+    animation-play-state: paused;
+  }
+  /* Hover overrides reduced-motion — user explicitly wants to see the animation */
+  .hp-ticker:hover .hp-ticker-track {
+    animation-play-state: running;
+  }
 }
 
 /* ─── Stats ─── */

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -1,0 +1,7 @@
+{
+  "classes": 33,
+  "properties": 145,
+  "shapes": 32,
+  "relationships": 52,
+  "designations": 7
+}


### PR DESCRIPTION
Ticker now shows 'many languages' in 8 languages. Hover overrides prefers-reduced-motion. Fixed Vite warning by importing stats.json from src/data/.