### PR TITLE
fix: ticker text descenders being clipped

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -524,6 +524,8 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
   overflow: hidden;
   max-width: 700px;
   margin-top: 0.25rem;
+  /* Vertical padding so italic descenders (p, g, y, ы) aren't clipped */
+  padding: 0.15em 0 0.35em;
   /* Fade edges */
   -webkit-mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
   mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
@@ -541,6 +543,7 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
   font-style: italic;
   font-size: clamp(2rem, 5vw, 4rem);
   font-weight: 500;
+  line-height: 1.2;
   color: #7ee0d4;
   padding-right: 2.5rem;
   letter-spacing: -0.01em;


### PR DESCRIPTION
Added vertical padding to ticker container so italic descenders (p, g, y, ы) in translations like 'plusieurs langues', 'Sprachen', 'idiomas' are no longer cut off by overflow:hidden.