### PR TITLE
fix: etymology root + rotating value-proposition taglines

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,7 @@ const year = new Date().getFullYear()
         <img src="/logo-glossarist.svg" alt="Glossarist" width="32" height="30" />
         <span>Glossarist</span>
       </a>
-      <p class="g-footer-tagline g-greek">γλωσσάριον — for multi-language concept systems</p>
+      <p class="g-footer-tagline g-greek">γλῶσσα · tongue, language — the root of glossary</p>
     </div>
 
     <nav class="g-footer-nav">

--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { premierProjects } from '../data/projects'
 import stats from '../data/stats.json'
 
@@ -20,6 +20,28 @@ const langCycle = [
 
 // Duplicate the list for seamless infinite scroll
 const tickerItems = computed(() => [...langCycle, ...langCycle])
+
+// Rotating value-proposition taglines
+const motdLines = [
+  'Convergence of scripts',
+  'Expression of ideas',
+  'Lineage of concepts',
+  'Relationships between terms',
+  'Multilingual datasets',
+  'Machine-readable glossaries',
+]
+const motdIndex = ref(0)
+let motdTimer: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  motdTimer = setInterval(() => {
+    motdIndex.value = (motdIndex.value + 1) % motdLines.length
+  }, 3500)
+})
+
+onUnmounted(() => {
+  if (motdTimer) clearInterval(motdTimer)
+})
 
 const codePanels = {
   yaml: {
@@ -93,8 +115,8 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
         <div class="hp-hero-logo-row">
           <img src="/logo-glossarist.svg" alt="Glossarist" class="hp-hero-logo" width="120" height="113" />
           <div class="hp-hero-meta">
-            <span class="hp-hero-greek">γλωσσάριον</span>
-            <span class="hp-hero-greek-sub">glōssárion · a small glossary</span>
+            <span class="hp-hero-greek">γλῶσσα</span>
+            <span class="hp-hero-greek-sub">glôssa · tongue, language — the root of "glossary"</span>
           </div>
         </div>
 
@@ -126,6 +148,15 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
             GitHub
           </a>
+        </div>
+
+        <div class="hp-motd">
+          <span class="hp-motd-label">Why Glossarist</span>
+          <span class="hp-motd-rotator">
+            <Transition name="motd-fade" mode="out-in">
+              <span :key="motdIndex" class="hp-motd-text">{{ motdLines[motdIndex] }}</span>
+            </Transition>
+          </span>
         </div>
       </div>
     </section>
@@ -515,6 +546,50 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
   flex-wrap: wrap;
   gap: 0.75rem;
   margin-bottom: 0;
+}
+
+/* ─── Rotating value-proposition taglines ─── */
+.hp-motd {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 2rem;
+  font-family: var(--g-font-display);
+}
+.hp-motd-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(184, 245, 236, 0.45);
+  white-space: nowrap;
+}
+.hp-motd-rotator {
+  position: relative;
+  display: inline-block;
+  height: 1.4em;
+  overflow: hidden;
+}
+.hp-motd-text {
+  display: inline-block;
+  font-family: 'EB Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: rgba(232, 238, 245, 0.85);
+  white-space: nowrap;
+}
+.motd-fade-enter-active,
+.motd-fade-leave-active {
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+.motd-fade-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+.motd-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
 }
 
 /* ─── Language ticker ─── */

--- a/src/components/LogoMerge.astro
+++ b/src/components/LogoMerge.astro
@@ -32,6 +32,6 @@
     <text x="95" y="220" text-anchor="middle" class="merge-sub-wen" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#4977a4">Pattern · Culture · Writing</text>
     <text x="467" y="196" text-anchor="middle" class="merge-lbl-logo" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" letter-spacing="0.08em" fill="#97a4b7">ONE MARK</text>
     <text x="815" y="200" text-anchor="middle" class="merge-lbl-gl" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="800" fill="#3fb6b0">ΓΛ</text>
-    <text x="815" y="220" text-anchor="middle" class="merge-sub-gl" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#60abbc">Greek letters · γλωσσάριον</text>
+    <text x="815" y="220" text-anchor="middle" class="merge-sub-gl" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#60abbc">Greek letters · γλῶσσα</text>
   </svg>
 </div>

--- a/src/content/pages/about.mdx
+++ b/src/content/pages/about.mdx
@@ -14,8 +14,8 @@ import LogoMerge from '../../components/LogoMerge.astro'
     <div class="hero-logo-row">
       <img src="/logo-glossarist.svg" alt="Glossarist logo" class="hero-logo-img" width="160" height="151" />
       <div class="hero-meta">
-        <span class="hero-greek">γλωσσάριον</span>
-        <span class="hero-greek-meta">glōssárion · a small glossary</span>
+        <span class="hero-greek">γλῶσσα</span>
+        <span class="hero-greek-meta">glôssa · tongue, language — the root of "glossary"</span>
       </div>
     </div>
     <h1 class="hero-title">
@@ -45,12 +45,12 @@ import LogoMerge from '../../components/LogoMerge.astro'
     </div>
     <div class="name-grid">
       <div class="name-display">
-        <span class="name-greek">γλωσσάριον</span>
-        <span class="name-translit">glōssárion</span>
-        <span class="name-translation">— a small glossary, a vocabulary</span>
+        <span class="name-greek">γλῶσσα</span>
+        <span class="name-translit">glôssa</span>
+        <span class="name-translation">tongue, language — the root of "glossary"</span>
       </div>
       <div class="name-body">
-        <p><strong>Glossarist</strong> takes its name from the Greek word <em>γλωσσάριον</em> (<em>glōssárion</em>) — a small glossary or vocabulary. The name reflects our mission: to provide tools that manage glossaries and concept systems with the rigor that international standards demand, while remaining accessible and practical.</p>
+        <p><strong>Glossarist</strong> takes its name from the Greek root <em>γλῶσσα</em> (<em>glôssa</em>) — meaning both <em>tongue</em> (the organ) and <em>language</em> (the faculty of speech). From this root came <em>γλωσσάριον</em> (a word-list, a vocabulary), which through Latin <em>glossarium</em> gave English "glossary." The name reflects our mission: to give structured, rigorous form to the way concepts are expressed across languages — one concept, many tongues.</p>
       </div>
     </div>
   </div>
@@ -111,12 +111,12 @@ import LogoMerge from '../../components/LogoMerge.astro'
           </div>
         </div>
         <div class="root-tags">
-          <span class="root-tag">γλωσσάριον</span>
+          <span class="root-tag">γλῶσσα</span>
           <span class="root-tag">Classification</span>
           <span class="root-tag">Precision</span>
         </div>
 
-        **ΓΛ** — the Greek capital letters Gamma and Lambda — reference *γλωσσάριον*. Greek is the language of classical scholarship and the root of much modern scientific terminology.
+        **ΓΛ** — the Greek capital letters Gamma and Lambda — spell the first two letters of *γλῶσσα* (glôssa), the root of "glossary." Greek is the language of classical scholarship and the root of much modern scientific terminology.
 
         The angular geometric forms of ΓΛ represent **precision** and **classification** — the systematic ordering of knowledge that underpins terminology work.
 


### PR DESCRIPTION
Replaced 'a small glossary' with the true root γλῶσσα (tongue, language). Added rotating taglines explaining why people need Glossarist.