### PR TITLE
fix: motd rotation animates even with prefers-reduced-motion

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -450,10 +450,12 @@
   /* ---------- Reduced motion ---------- */
   @media (prefers-reduced-motion: reduce) {
     html { scroll-behavior: auto; }
+    /* Disable CSS animations (continuous loops like ticker) but keep
+       transitions (brief one-shot effects like the motd fade) so the
+       rotating taglines still animate visibly. */
     * {
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
     }
   }
 }


### PR DESCRIPTION
Removed the blanket transition-duration override from the reduced-motion media query so the motd fade transition stays visible. CSS animations (ticker) are still disabled.