### PR TITLE
fix: merge taglines into green ticker, remove separate Why Glossarist section

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed } from 'vue'
 import { premierProjects } from '../data/projects'
 import stats from '../data/stats.json'
 
@@ -7,41 +7,28 @@ const st = stats
 
 const activeCodeTab = ref('yaml')
 
+// Ticker items: "many languages" translations interleaved with
+// value-proposition taglines, all scrolling in the green text below
+// "One concept,".
 const langCycle = [
-  { code: 'eng', term: 'many languages' },
-  { code: 'fra', term: 'plusieurs langues' },
-  { code: 'deu', term: 'viele Sprachen' },
-  { code: 'spa', term: 'muchos idiomas' },
-  { code: 'zho', term: '多种语言' },
-  { code: 'ara', term: 'لغات كثيرة' },
-  { code: 'rus', term: 'много языков' },
-  { code: 'jpn', term: '多くの言語' },
+  { term: 'many languages' },
+  { term: 'Convergence of scripts' },
+  { term: 'plusieurs langues' },
+  { term: 'Expression of ideas' },
+  { term: 'viele Sprachen' },
+  { term: 'Lineage of concepts' },
+  { term: 'muchos idiomas' },
+  { term: 'Relationships between terms' },
+  { term: '多种语言' },
+  { term: 'Multilingual datasets' },
+  { term: 'لغات كثيرة' },
+  { term: 'Machine-readable glossaries' },
+  { term: 'много языков' },
+  { term: '多くの言語' },
 ]
 
 // Duplicate the list for seamless infinite scroll
 const tickerItems = computed(() => [...langCycle, ...langCycle])
-
-// Rotating value-proposition taglines
-const motdLines = [
-  'Convergence of scripts',
-  'Expression of ideas',
-  'Lineage of concepts',
-  'Relationships between terms',
-  'Multilingual datasets',
-  'Machine-readable glossaries',
-]
-const motdIndex = ref(0)
-let motdTimer: ReturnType<typeof setInterval> | null = null
-
-onMounted(() => {
-  motdTimer = setInterval(() => {
-    motdIndex.value = (motdIndex.value + 1) % motdLines.length
-  }, 3500)
-})
-
-onUnmounted(() => {
-  if (motdTimer) clearInterval(motdTimer)
-})
 
 const codePanels = {
   yaml: {
@@ -148,15 +135,6 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
             GitHub
           </a>
-        </div>
-
-        <div class="hp-motd">
-          <span class="hp-motd-label">Why Glossarist</span>
-          <span class="hp-motd-rotator">
-            <Transition name="motd-fade" mode="out-in">
-              <span :key="motdIndex" class="hp-motd-text">{{ motdLines[motdIndex] }}</span>
-            </Transition>
-          </span>
         </div>
       </div>
     </section>
@@ -548,50 +526,6 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
   margin-bottom: 0;
 }
 
-/* ─── Rotating value-proposition taglines ─── */
-.hp-motd {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-top: 2rem;
-  font-family: var(--g-font-display);
-}
-.hp-motd-label {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(184, 245, 236, 0.45);
-  white-space: nowrap;
-}
-.hp-motd-rotator {
-  position: relative;
-  display: inline-block;
-  height: 1.4em;
-  overflow: hidden;
-}
-.hp-motd-text {
-  display: inline-block;
-  font-family: 'EB Garamond', Georgia, serif;
-  font-style: italic;
-  font-size: 1.125rem;
-  font-weight: 500;
-  color: rgba(232, 238, 245, 0.85);
-  white-space: nowrap;
-}
-.motd-fade-enter-active,
-.motd-fade-leave-active {
-  transition: opacity 0.4s ease, transform 0.4s ease;
-}
-.motd-fade-enter-from {
-  opacity: 0;
-  transform: translateY(10px);
-}
-.motd-fade-leave-to {
-  opacity: 0;
-  transform: translateY(-10px);
-}
-
 /* ─── Language ticker ─── */
 .hp-ticker {
   display: block;
@@ -610,7 +544,7 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
   align-items: center;
   gap: 0;
   white-space: nowrap;
-  animation: hp-ticker-scroll 24s linear infinite;
+  animation: hp-ticker-scroll 40s linear infinite;
   will-change: transform;
 }
 .hp-ticker-item {


### PR DESCRIPTION
The value-proposition taglines now scroll in the same green ticker below 'One concept,' interleaved with the 'many languages' translations. Removed the separate Why Glossarist rotating section.