### PR TITLE
fix: ticker always animates + Chinese traditional/simplified split

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -19,6 +19,7 @@ const langCycle = [
   { term: 'Lineage of concepts' },
   { term: 'muchos idiomas' },
   { term: 'Relationships between terms' },
+  { term: '多種語言' },
   { term: '多种语言' },
   { term: 'Multilingual datasets' },
   { term: 'لغات كثيرة' },
@@ -572,15 +573,6 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
 }
 .hp-ticker:hover .hp-ticker-track {
   animation-play-state: paused;
-}
-@media (prefers-reduced-motion: reduce) {
-  .hp-ticker-track {
-    animation-play-state: paused;
-  }
-  /* Hover overrides reduced-motion — user explicitly wants to see the animation */
-  .hp-ticker:hover .hp-ticker-track {
-    animation-play-state: running;
-  }
 }
 
 /* ─── Stats ─── */

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -450,12 +450,5 @@
   /* ---------- Reduced motion ---------- */
   @media (prefers-reduced-motion: reduce) {
     html { scroll-behavior: auto; }
-    /* Disable CSS animations (continuous loops like ticker) but keep
-       transitions (brief one-shot effects like the motd fade) so the
-       rotating taglines still animate visibly. */
-    * {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-    }
   }
 }


### PR DESCRIPTION
Removed the blanket animation-duration override that killed the ticker when prefers-reduced-motion was enabled. Ticker now always scrolls. Also added Traditional Chinese (多種語言) alongside Simplified (多种语言).