### PR TITLE
docs: partitive hyperedges — model page, relationships update, blog post

### DIFF
--- a/src/content/blog/2026-07-22-partitive-hyperedges.mdx
+++ b/src/content/blog/2026-07-22-partitive-hyperedges.mdx
@@ -1,0 +1,159 @@
+---
+title: "Partitive hyperedges — one-to-many decompositions with diagram notation"
+description: "Glossarist v3.2 introduces PartitiveHyperedge for n-ary partitive decompositions that carry enumeration completeness and VIM-style diagram markers — closing a gap binary broader_partitive / narrower_partitive edges could not fill. Now synced across glossarist-ruby, glossarist-js, concept-model, and concept-browser."
+authors:
+  - Ribose
+date: 2026-07-22
+---
+
+{/* byline rendered by BlogLayout */}
+Today we're announcing **`PartitiveHyperedge`** — a new model class for one-to-many partitive decompositions that carry enumeration completeness and VIM-style diagram notation. It complements the existing binary `broader_partitive` / `narrower_partitive` edges, which remain unchanged. The model is now synced across [glossarist-ruby](/docs/software/glossarist-ruby), [glossarist-js](/docs/software/glossarist-js), [concept-model](https://github.com/glossarist/concept-model), and [concept-browser](/docs/software/concept-browser).
+
+## Why a new relationship shape?
+
+The VIM concept-relationship diagrams (OIML V 2:2012 and successors) encode information that the binary `broader_partitive` / `narrower_partitive` pair cannot faithfully represent:
+
+1. **One-to-many membership as a single invariant.** A "rake" notation on the diagram says "this whole is composed of exactly these parts as a single relationship." Splitting the rake into N binary edges loses the "this is one rake" invariant — the same comprehensive can appear in multiple independent rakes, and the membership of each rake is significant.
+2. **Plurality markers.** VIM diagrams use a close-set double line at the receiver end to say "several parts of the same type are involved," and a dashed line to say "plurality is uncertain." These travel with the rake, not with any single binary edge.
+3. **Enumeration completeness.** A rake whose backline ends without ellipsis is **closed** — the listed teeth are ALL the parts of the comprehensive. A rake with a trailing ellipsis is **open** — others exist but are not encoded. This is a separate axis from plurality.
+
+`PartitiveHyperedge` captures all three on a single object. See the new [Partitive Hyperedges](/model/partitive-hyperedges) model page for the full field reference.
+
+## The model
+
+```
+PartitiveHyperedge
+  +comprehensive: ConceptRef [1]              // the whole
+  +parts:         ConceptRef [1..*]           // the parts
+  +enumeration:   PartitiveEnumeration [0..1] // default: closed
+  +markers:       PluralityMarker [0..*]      // diagram notation
+  +content:       LocalizedString [0..1]      // optional label / note
+```
+
+Two new SKOS taxonomies — [partitive-enumeration](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/partitive-enumeration.ttl) (`closed` / `open`) and [plurality-marker](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/plurality-marker.ttl) (`double` / `dashed`) — are the single source of truth. They flow into Ruby via `config.yml`, into the JSON Schema as enum values, and into the SHACL shapes via `sh:class skos:Concept` + `sh:valuesFrom`, matching the pattern used by every other enum in the model.
+
+## YAML shape
+
+Hyperedges live at the concept level (alongside `related`), not on the data payload — closing a long-standing MECE trap where writing relationships at the data level bypassed schema-version detection.
+
+```yaml
+termid: "112-02-09"
+status: valid
+
+partitive_hyperedges:
+  - comprehensive: { source: VIM, id: "112-02-09" }
+    parts:
+      - { source: VIM, id: "112-02-10" }   # measured quantity value
+      - { source: VIM, id: "112-02-26" }   # measurement uncertainty
+    enumeration: closed      # ALL parts encoded — adding/removing changes the relationship
+    markers: [double]        # close-set double line on the rake
+    content:
+      eng: |
+        A measurement result is composed of a measured quantity value
+        and a measurement uncertainty. No other components are part
+        of the result.
+```
+
+The wire format is consistent with everything else in v3: snake_case keys, `ConceptRef` shape for both comprehensive and parts, optional `content` as a localized hash.
+
+## When to use a hyperedge vs. binary edges
+
+Both shapes coexist — no automatic consolidation is performed. The choice depends on what the source data needs to express.
+
+| Shape | Use when … |
+|-------|------------|
+| Binary `broader_partitive` / `narrower_partitive` | The relationship is pairwise and does not need enumeration or diagram-notation metadata |
+| `PartitiveHyperedge` | The relationship is one-to-many with diagram metadata, or the "these are all the parts" invariant matters |
+
+A concept can carry binary edges for pairwise cross-references *and* hyperedges describing its own decomposition into parts, simultaneously.
+
+## RDF emission and SHACL
+
+Each hyperedge emits one `gloss:PartitiveHyperedge` subject anchored to its carrying concept via `gloss:hasPartitiveHyperedge`:
+
+```turtle
+<concept/112-02-09> gloss:hasPartitiveHyperedge [
+  a gloss:PartitiveHyperedge ;
+  gloss:comprehensive <concept/112-02-09> ;
+  gloss:hasPart <concept/112-02-10>, <concept/112-02-26> ;
+  gloss:enumeration <partitiveEnumeration/closed> ;
+  gloss:hasPluralityMarker <pluralityMarker/double> ;
+  gloss:hyperedgeContent "A measurement result is composed of ..." ;
+] .
+```
+
+A new soft SHACL constraint — `gloss:PartitiveHyperedgeOwnershipShape` — fires a warning when a hyperedge's carrying concept is not its comprehensive. The constraint handles both encoding shapes (ConceptRef node with `gloss:conceptRefId`, or direct concept URI) via a `COALESCE` in SPARQL, so it stays useful regardless of how the comprehensive is serialized.
+
+## Validation
+
+Shape checks live in the validator framework, not in the model constructor — matching how every other enum in Glossarist works:
+
+- **`comprehensive`** must be a non-empty `ConceptRef` (source or id required)
+- **`parts`** must contain at least one `ConceptRef`; cannot include the comprehensive (no self-loop)
+- **`markers`** cannot contain duplicates; values must come from `PLURALITY_MARKER_VALUES`
+- **`enumeration`** values must come from `PARTITIVE_ENUMERATION_VALUES`
+
+In Ruby, this is `Glossarist::Validation::Rules::PartitiveHyperedgeRule` (rule code `GLS-220`). In JS, it's `PartitiveHyperedgeShapeRule`. Both auto-register with the default validator chain.
+
+## Cross-repo rollout
+
+Hyperedge support is now consistent across the four repos:
+
+- **[concept-model](https://github.com/glossarist/concept-model)** — LUTAML model, JSON Schema, SHACL shapes, OWL ontology, two new SKOS taxonomies with `skos:hasTopConcept`, four canonical example fixtures (closed, open, marked, plain), and CI helpers (`scripts/validate-examples.py`, `scripts/check-enum-drift.py`) to catch future drift between the four sources.
+- **[glossarist-ruby](/docs/software/glossarist-ruby)** — `V3::PartitiveHyperedge` model on `ManagedConcept#partitive_hyperedges`, `Rdf::GlossHyperedge` view class emitting `gloss:PartitiveHyperedge` triples via the existing `ConceptToGlossTransform`, `PartitiveHyperedgeRule` validator (GLS-220), `ManagedConcept.detect_schema_version` now detects V3 from hyperedges alone. Enum values SSOT-loaded from `config.yml` via `GlossaryDefinition`.
+- **[glossarist-js](/docs/software/glossarist-js)** — `PartitiveHyperedge` model with symmetric throw on invalid enumeration/markers, construction-time comprehensive + parts + self-loop validation, content normalized to a localized hash. Wired through parser (managed + canonical formats), serializer (snake_case wire key), `ConceptLevelDiff`, reference resolver, TypeScript declarations, and `PartitiveHyperedgeShapeRule` validator.
+- **[concept-browser](/docs/software/concept-browser)** — `PartitiveHyperedgeList.vue` renders hyperedges with enumeration and marker badges, `use-concept-edges.ts` integrates them with binary edges, build pipeline emits `gl:partitiveHyperedges` JSON-LD, stats include hyperedge counts, and `scripts/migrate-vocab-data.mjs` migrates legacy `partitive_plural` blocks from vocab PR #65.
+
+The migration is fully additive. Existing datasets keep working unchanged. Hyperedges only appear when explicitly authored.
+
+## Architectural cleanup
+
+While wiring hyperedges through every layer, we also closed two long-standing issues the contribution surfaced:
+
+- **V3 `related` placement (MECE).** `related` now lives *only* on `V3::ManagedConcept`, not on `V3::ManagedConceptData`. The V2→V3 migration moves any data-level entries up to the concept level. This closes the trap where writing to `data.related` silently bypassed `detect_schema_version` (which keys off `concept.related`).
+- **Enum single-source-of-truth.** The same enum values used to be declared in five places (LUTAML model, JSON Schema, OWL class comment, SHACL `sh:in`, SKOS taxonomy). Adding a value meant editing all five. The new SHACL pattern uses `skos:Concept` + `sh:valuesFrom <taxonomy>`, making the SKOS taxonomy the load-bearing source and `scripts/check-enum-drift.py` catches any future drift in CI.
+
+## Upgrading
+
+The release is additive — no breaking changes.
+
+```bash
+# glossarist-ruby
+bundle update glossarist     # → 2.13
+
+# glossarist-js
+npm install glossarist@latest # → 0.5
+
+# concept-browser (in your deployment repo)
+npm install --ignore-scripts @glossarist/concept-browser@latest
+npx concept-browser build
+
+# concept-model (if you vendor it directly)
+git fetch --tags && git checkout v3.2
+```
+
+If you have legacy vocab data using the `partitive_plural` block shape (vocab PR #65), run the migration helper:
+
+```bash
+node scripts/migrate-vocab-data.mjs ./datasets/my-vocab
+```
+
+It rewrites `partitive_plural` blocks in-place to `partitive_hyperedges`, mapping `complete: false` to `enumeration: open`, and `double` / `dashed` flags to `markers`. Idempotent.
+
+## What's next
+
+- **Emitter-level SHACL conformance** — closing remaining gaps between glossarist-ruby's RDF output and the canonical shapes
+- **Hyperedge-aware concept graph** in the browser — visual "rake" rendering with double/dashed stroke styles
+- **V4 schema drafting** — flattening some long-standing V2/V3 divergences, informed by the consolidation patterns we applied to `related` this round
+
+If you build terminology tooling, glossaries, or standards vocabularies, we'd love to hear from you. [Open an issue](https://github.com/glossarist/concept-model/issues) on any of the repositories.
+
+## Further reading
+
+- [Partitive Hyperedges](/model/partitive-hyperedges) — full model reference
+- [Relationships](/model/relationships) — 52 binary typed relationship kinds
+- [Concepts](/model/concepts) — ManagedConcept and LocalizedConcept
+- [Datasets & Sections](/model/datasets) — dataset layout and register.yaml
+- [glossarist-ruby](/docs/software/glossarist-ruby) — Ruby SDK
+- [glossarist-js](/docs/software/glossarist-js) — JavaScript SDK
+- [Concept Browser](/docs/software/concept-browser) — static SPA

--- a/src/content/model/concepts.mdx
+++ b/src/content/model/concepts.mdx
@@ -17,6 +17,7 @@ A `ManagedConcept` is the top-level concept entity in Glossarist. It represents 
 | `uri` | anyURI | 0..1 | URI for the concept |
 | `status` | [conceptStatus](/reference/entity-fields) | 0..1 | Lifecycle status |
 | `related` | [RelatedConcept](/reference/entity-fields)[] | 0..* | Related concepts |
+| `partitive_hyperedges` | [PartitiveHyperedge](/model/partitive-hyperedges)[] | 0..* | One-to-many partitive decompositions with diagram notation |
 | `dates` | [ConceptDate](/reference/entity-fields)[] | 0..* | Governance events |
 | `sources` | [ConceptSource](/model/sources)[] | 0..* | Concept-level sources |
 | `domains` | [Reference](/reference/entity-fields)[] | 0..* | Subject area references (rendered as `<domain>`) |

--- a/src/content/model/partitive-hyperedges.mdx
+++ b/src/content/model/partitive-hyperedges.mdx
@@ -1,0 +1,156 @@
+---
+title: Partitive Hyperedges
+description: One-to-many partitive decompositions with enumeration and diagram notation, complementing binary broader_partitive / narrower_partitive edges
+---
+
+# Partitive Hyperedges
+
+A **`PartitiveHyperedge`** is a one-to-many partitive decomposition: one comprehensive concept (the whole) is related to one or more part concepts as a *single* relationship. It captures invariants that binary [`broader_partitive`](/model/relationships#hierarchical-relationships) / `narrower_partitive` edges cannot:
+
+- **Set membership** — which comprehensive owns which parts, as one rake rather than N independent binary edges
+- **Plurality markers** — diagram-notation flags (`double`, `dashed`) carried from VIM concept-relationship diagrams
+- **Enumeration completeness** — whether the encoded parts are ALL the parts (`closed`) or only SOME (`open`)
+
+Hyperedges are a V3-only construct. They live on the [`ManagedConcept`](/model/concepts#managedconcept) (concept level, alongside `related`), not on its data payload.
+
+## When to use a hyperedge vs. a binary edge
+
+| Shape | Use when … |
+|-------|------------|
+| Binary `broader_partitive` / `narrower_partitive` | The relationship is pairwise and does not need enumeration or diagram-notation metadata |
+| `PartitiveHyperedge` | The relationship is one-to-many with diagram metadata, or the "these are all the parts" invariant matters |
+
+Both shapes coexist on the same concept — no automatic consolidation is performed. A concept can carry binary edges for pairwise cross-references *and* hyperedges describing its own decomposition into parts.
+
+## Model
+
+```
+PartitiveHyperedge
+  +comprehensive: ConceptRef [1]              // the whole
+  +parts:         ConceptRef [1..*]           // the parts
+  +enumeration:   PartitiveEnumeration [0..1] // default: closed
+  +markers:       PluralityMarker [0..*]      // diagram notation
+  +content:       LocalizedString [0..1]      // optional label / note
+```
+
+Wired into `ManagedConcept` as `+partitive_hyperedges: PartitiveHyperedge [0..*]`.
+
+### PartitiveEnumeration
+
+Two values, SSOT-loaded from the [partitive-enumeration SKOS taxonomy](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/partitive-enumeration.ttl):
+
+- **`closed`** *(default)* — the encoded parts are ALL the parts of the comprehensive. Adding or removing a part would change the relationship.
+- **`open`** — the encoded parts are SOME of the parts; others may exist but are not encoded.
+
+### PluralityMarker
+
+Two values, SSOT-loaded from the [plurality-marker SKOS taxonomy](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/plurality-marker.ttl). Orthogonal to enumeration — both may be set on the same hyperedge.
+
+- **`double`** — close-set double line at the receiver end of the rake. Indicates that several partitive concepts of a given type are involved.
+- **`dashed`** — broken or dashed line. Indicates that plurality is uncertain.
+
+## YAML authoring
+
+Hyperedges live under the top-level `partitive_hyperedges` key on a managed concept:
+
+```yaml
+termid: "112-02-09"
+status: valid
+
+partitive_hyperedges:
+  - comprehensive:
+      source: VIM
+      id: "112-02-09"
+    parts:
+      - { source: VIM, id: "112-02-10" }   # measured quantity value
+      - { source: VIM, id: "112-02-26" }   # measurement uncertainty
+    enumeration: closed
+    markers:
+      - double
+    content:
+      eng: |
+        A measurement result is composed of a measured quantity value
+        and a measurement uncertainty. No other components are part
+        of the result.
+```
+
+### Minimal (closed, no markers)
+
+When `enumeration` is omitted, the schema default (`closed`) applies. Markers default to an empty array.
+
+```yaml
+partitive_hyperedges:
+  - comprehensive: { source: VIM, id: "1.1" }
+    parts:
+      - { source: VIM, id: "1.2" }
+      - { source: VIM, id: "1.3" }
+```
+
+### Open enumeration
+
+Use `enumeration: open` when the encoded parts are a partial list:
+
+```yaml
+partitive_hyperedges:
+  - comprehensive: { source: EXAMPLE, id: "X" }
+    parts:
+      - { source: EXAMPLE, id: "Y" }
+    enumeration: open   # other parts may exist
+```
+
+### Cross-dataset parts
+
+Parts and comprehensive can reference concepts in other datasets using the same `source` + `id` shape as binary relationships:
+
+```yaml
+partitive_hyperedges:
+  - comprehensive:
+      source: urn:oiml:pub:v:2-200:2012
+      id: "2.9"
+    parts:
+      - source: urn:oiml:pub:v:1:1993
+        id: "2.10"
+```
+
+## RDF emission
+
+Hyperedges emit one `gloss:PartitiveHyperedge` subject per entry, anchored to the carrying concept via `gloss:hasPartitiveHyperedge`:
+
+```turtle
+<concept/112-02-09> gloss:hasPartitiveHyperedge [
+  a gloss:PartitiveHyperedge ;
+  gloss:comprehensive <concept/112-02-09> ;
+  gloss:hasPart <concept/112-02-10>, <concept/112-02-26> ;
+  gloss:enumeration <partitiveEnumeration/closed> ;
+  gloss:hasPluralityMarker <pluralityMarker/double> ;
+  gloss:hyperedgeContent "A measurement result is composed of ..." ;
+] .
+```
+
+Enumeration and markers serialize as `skos:Concept` references into the corresponding taxonomies (not as xsd:string literals), matching the SHACL `sh:valuesFrom` pattern used by every other enum in the model.
+
+## Validation
+
+Shape checks live in the validator framework, not in the model constructor:
+
+- **`comprehensive`** must be a non-empty `ConceptRef` (source or id required)
+- **`parts`** must contain at least one `ConceptRef`; cannot include the comprehensive (no self-loop)
+- **`markers`** cannot contain duplicates; values must be in `PLURALITY_MARKER_VALUES`
+- **`enumeration`** values must be in `PARTITIVE_ENUMERATION_VALUES`
+
+### Ownership invariant
+
+A soft `sh:Warning` SHACL constraint (`gloss:PartitiveHyperedgeOwnershipShape`) flags hyperedges whose carrying concept is not the comprehensive — useful for catching accidental cross-references without blocking legitimate indexing patterns.
+
+## Standards alignment
+
+Hyperedges are a Glossarist extension to ISO 25964's partitive hierarchy. The binary `broader_partitive` / `narrower_partitive` types continue to map directly to `iso-thes:broaderPartitive` / `iso-thes:narrowerPartitive`; the n-ary hyperedge has no direct SKOS equivalent and serializes as a `gloss:PartitiveHyperedge` blank node or named node.
+
+The `double` and `dashed` markers originate from VIM concept-relationship diagrams (OIML V 2:2012, Fig. A.6 and similar). They travel with the hyperedge so the rendering layer can reproduce the source diagram's notation.
+
+## See also
+
+- [Relationships](/model/relationships) — binary typed relationships (52 types)
+- [Concepts](/model/concepts) — `ManagedConcept` and `LocalizedConcept`
+- [Datasets & Sections](/model/datasets) — where hyperedges live in the dataset layout
+- [Concept model v3.1 release notes](https://github.com/glossarist/concept-model/blob/main/RELEASE_NOTES.md) — full release notes

--- a/src/content/model/relationships.mdx
+++ b/src/content/model/relationships.mdx
@@ -58,6 +58,28 @@ related:
     content: "3.1.1.1.2"      # NTP: 3.1.1.1.2 is a part of this
 ```
 
+### Partitive hyperedges (n-ary)
+
+When a partitive decomposition is *one-to-many* and the membership is
+jointly significant, use a `PartitiveHyperedge` instead of N binary
+`broader_partitive` / `narrower_partitive` edges. Hyperedges carry
+enumeration completeness (`closed` / `open`) and diagram-notation
+markers (`double` / `dashed`) that binary edges cannot.
+
+```yaml
+partitive_hyperedges:
+  - comprehensive: { source: VIM, id: "112-02-09" }
+    parts:
+      - { source: VIM, id: "112-02-10" }
+      - { source: VIM, id: "112-02-26" }
+    enumeration: closed      # ALL parts encoded
+    markers: [double]        # close-set double line on the rake
+```
+
+Both shapes coexist on the same concept — no automatic consolidation
+is performed. See [Partitive Hyperedges](/model/partitive-hyperedges)
+for the full model, YAML authoring, RDF emission, and validation rules.
+
 ### Equivalence and mapping
 
 ```yaml


### PR DESCRIPTION
## Summary

- Adds a new model page at `/model/partitive-hyperedges` documenting the `PartitiveHyperedge` class (one-to-many partitive decompositions with enumeration completeness and VIM-style diagram notation), its two enum taxonomies (`PartitiveEnumeration`: closed/open; `PluralityMarker`: double/dashed), YAML authoring, RDF emission, validation rules, and standards alignment.
- Updates `/model/concepts` ManagedConcept field list to include `partitive_hyperedges`.
- Updates `/model/relationships` to add a "Partitive hyperedges (n-ary)" subsection under YAML Authoring, with a forward-link to the new model page and guidance on when to use a hyperedge vs. binary `broader_partitive` / `narrower_partitive`.
- Adds a blog post at `/blog/2026-07-22-partitive-hyperedges` announcing the cross-repo rollout (glossarist-ruby, glossarist-js, concept-model, concept-browser), the V3 `related` placement consolidation, and the enum SSOT cleanup.

## Why

The PartitiveHyperedge work landed across all four downstream repos but had no user-facing documentation. This PR closes that gap with a model reference page, two doc updates, and an announcement post. The model itself was already shipped in the underlying repos; this PR is purely documentation.

## Test plan

- [x] `npm test` — 214 tests pass
- [x] `npx astro build` — 84 pages built including `/model/partitive-hyperedges` and `/blog/2026-07-22-partitive-hyperedges`
- [ ] Visual review of `/model/partitive-hyperedges` rendering (code blocks, tables, cross-links)
- [ ] Visual review of `/blog/2026-07-22-partitive-hyperedges` rendering (byline, code blocks, tables)
