### PR TITLE
docs: SVG diagrams for PartitiveRelation and other relations

### DIFF
--- a/public/images/model/relations/associative.svg
+++ b/public/images/model/relations/associative.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 220" role="img" aria-labelledby="title desc">
+  <title id="title">Associative relation — double-headed arrow</title>
+  <desc id="desc">ISO 704 / 10241-1 associative (pragmatic) relation. A non-hierarchical thematic connection between two concepts, depicted as a double-headed arrow. All associative subtypes use this single visual form.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-edge { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; fill: #1f2937; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .edge { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+    </style>
+    <marker id="arrow-start" viewBox="0 0 10 10" refX="1" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 10 0 L 0 5 L 10 10 z" fill="#1f2937"/>
+    </marker>
+    <marker id="arrow-end" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/>
+    </marker>
+  </defs>
+
+  <rect width="540" height="220" fill="#ffffff"/>
+
+  <!-- concept A -->
+  <rect x="40" y="80" width="160" height="56" rx="8" class="box"/>
+  <text x="120" y="103" text-anchor="middle" class="label">thermometry</text>
+  <text x="120" y="121" text-anchor="middle" class="label-id">VIM 112-04-XX</text>
+
+  <!-- double-headed arrow -->
+  <line x1="200" y1="108" x2="340" y2="108" class="edge"
+        marker-start="url(#arrow-start)" marker-end="url(#arrow-end)"/>
+  <text x="270" y="98" text-anchor="middle" class="label-edge">related_concept</text>
+  <text x="270" y="125" text-anchor="middle" class="label-id">(associative)</text>
+
+  <!-- concept B -->
+  <rect x="340" y="80" width="160" height="56" rx="8" class="box"/>
+  <text x="420" y="103" text-anchor="middle" class="label">temperature</text>
+  <text x="420" y="121" text-anchor="middle" class="label-id">VIM 112-01-XX</text>
+
+  <text x="270" y="175" text-anchor="middle" class="label-note">Non-hierarchical thematic connection.</text>
+  <text x="270" y="190" text-anchor="middle" class="label-note">All associative subtypes use this single visual form.</text>
+</svg>

--- a/public/images/model/relations/binary-has-part.svg
+++ b/public/images/model/relations/binary-has-part.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 280" role="img" aria-labelledby="title desc">
+  <title id="title">Binary has_part / is_part_of edge</title>
+  <desc id="desc">A simple pairwise part-of assertion between two concepts. Used when no completeness, plurality, or per-partitive certainty claim is needed. Distinct from a PartitiveRelation which requires two or more partitives per ISO 704.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-edge { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; fill: #1f2937; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .edge { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+    </style>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/>
+    </marker>
+  </defs>
+
+  <rect width="540" height="280" fill="#ffffff"/>
+
+  <!-- subject (comprehensive) -->
+  <rect x="40" y="100" width="180" height="60" rx="8" class="box"/>
+  <text x="130" y="125" text-anchor="middle" class="label">bicycle</text>
+  <text x="130" y="143" text-anchor="middle" class="label-id">EXAMPLE 001</text>
+
+  <!-- arrow with label -->
+  <line x1="220" y1="130" x2="320" y2="130" class="edge" marker-end="url(#arrow)"/>
+  <text x="270" y="120" text-anchor="middle" class="label-edge">has_part</text>
+  <text x="270" y="148" text-anchor="middle" class="label-id">(inverse: is_part_of)</text>
+
+  <!-- object (partitive) -->
+  <rect x="320" y="100" width="180" height="60" rx="8" class="box"/>
+  <text x="410" y="125" text-anchor="middle" class="label">wheel</text>
+  <text x="410" y="143" text-anchor="middle" class="label-id">EXAMPLE 002</text>
+
+  <!-- caption -->
+  <text x="270" y="220" text-anchor="middle" class="label-id">Use binary edges for single pairwise assertions without</text>
+  <text x="270" y="236" text-anchor="middle" class="label-id">completeness or plurality claims. For 2+ partitives as a</text>
+  <text x="270" y="252" text-anchor="middle" class="label-id">unit, use PartitiveRelation (ISO 704 rake) instead.</text>
+</svg>

--- a/public/images/model/relations/external-concept-resolution.svg
+++ b/public/images/model/relations/external-concept-resolution.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 320" role="img" aria-labelledby="title desc">
+  <title id="title">ExternalConcept resolution via provided_by</title>
+  <desc id="desc">An ExternalConcept (status: external, minimal data) lives in Dataset A. When Dataset B is loaded and a matching concept is found, the collection manager adds a provided_by binary edge from the ExternalConcept to Dataset B's defining concept. Dataset B is untouched.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-edge { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; fill: #1f2937; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .label-set { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; fill: #6b7280; font-weight: 600; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .box-ext { fill: #fef3c7; stroke: #92400e; stroke-width: 2; stroke-dasharray: 4 3; }
+      .box-real { fill: #ecfdf5; stroke: #047857; stroke-width: 2; }
+      .edge { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+      .dataset-frame { fill: none; stroke: #d1d5db; stroke-width: 1; stroke-dasharray: 3 3; }
+    </style>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1f2937"/>
+    </marker>
+  </defs>
+
+  <rect width="540" height="320" fill="#ffffff"/>
+
+  <!-- Dataset A frame -->
+  <rect x="20" y="20" width="240" height="280" rx="10" class="dataset-frame"/>
+  <text x="140" y="40" text-anchor="middle" class="label-set">Dataset A</text>
+
+  <!-- Dataset B frame -->
+  <rect x="280" y="20" width="240" height="280" rx="10" class="dataset-frame"/>
+  <text x="400" y="40" text-anchor="middle" class="label-set">Dataset B</text>
+
+  <!-- ExternalConcept (in Dataset A) -->
+  <rect x="50" y="120" width="180" height="60" rx="8" class="box-ext"/>
+  <text x="140" y="143" text-anchor="middle" class="label">quantum field theory</text>
+  <text x="140" y="161" text-anchor="middle" class="label-id">ext-qft (status: external)</text>
+
+  <!-- Real defining concept (in Dataset B) -->
+  <rect x="310" y="120" width="180" height="60" rx="8" class="box-real"/>
+  <text x="400" y="143" text-anchor="middle" class="label">quantum field theory</text>
+  <text x="400" y="161" text-anchor="middle" class="label-id">qft (full definition)</text>
+
+  <!-- provided_by arrow from ExternalConcept to defining concept -->
+  <line x1="230" y1="150" x2="310" y2="150" class="edge" marker-end="url(#arrow)"/>
+  <text x="270" y="140" text-anchor="middle" class="label-edge">provided_by</text>
+
+  <!-- Caption -->
+  <text x="140" y="220" text-anchor="middle" class="label-note">Placeholder: knows the name,</text>
+  <text x="140" y="235" text-anchor="middle" class="label-note">no definition of its own.</text>
+  <text x="140" y="258" text-anchor="middle" class="label-id">status: external</text>
+
+  <text x="400" y="220" text-anchor="middle" class="label-note">Full concept with definition,</text>
+  <text x="400" y="235" text-anchor="middle" class="label-note">sources, designations.</text>
+  <text x="400" y="258" text-anchor="middle" class="label-id">status: valid</text>
+
+  <text x="270" y="295" text-anchor="middle" class="label-id">Edge added at collection level (human or auto-resolution).</text>
+</svg>

--- a/public/images/model/relations/generic-tree.svg
+++ b/public/images/model/relations/generic-tree.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 340" role="img" aria-labelledby="title desc">
+  <title id="title">Generic relation — ISO 704 tree notation</title>
+  <desc id="desc">ISO 704 generic (genus-species) relation. A superordinate concept branches down to subordinate concepts. A short branch with three dots indicates one or more other specific concepts exist but are not included. A heavy starting line indicates a separate terminological dimension.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .box-genus { fill: #eff6ff; stroke: #1d4ed8; stroke-width: 2; }
+      .tree { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+      .tree-heavy { stroke: #1f2937; stroke-width: 4; fill: none; }
+    </style>
+  </defs>
+
+  <rect width="540" height="340" fill="#ffffff"/>
+
+  <!-- superordinate (genus) -->
+  <rect x="180" y="30" width="180" height="56" rx="8" class="box box-genus"/>
+  <text x="270" y="55" text-anchor="middle" class="label">measurement unit</text>
+  <text x="270" y="73" text-anchor="middle" class="label-id">VIM 112-01-09</text>
+
+  <!-- trunk down from genus -->
+  <path d="M 270 86 L 270 140" class="tree-heavy"/>
+  <text x="290" y="115" class="label-note">heavy line = separate dimension</text>
+
+  <!-- horizontal branch -->
+  <path d="M 100 140 L 440 140" class="tree"/>
+
+  <!-- drops to each species -->
+  <path d="M 100 140 L 100 200" class="tree"/>
+  <path d="M 270 140 L 270 200" class="tree"/>
+
+  <!-- drop to ellipsis (3 dots) — "more exist" indicator -->
+  <path d="M 440 140 L 440 175" class="tree"/>
+  <circle cx="440" cy="180" r="2.5" fill="#1f2937"/>
+  <circle cx="440" cy="187" r="2.5" fill="#1f2937"/>
+  <circle cx="440" cy="194" r="2.5" fill="#1f2937"/>
+  <text x="460" y="190" class="label-note">more species exist</text>
+
+  <text x="270" y="160" text-anchor="middle" class="label-note">broader_generic / narrower_generic</text>
+
+  <!-- species 1 -->
+  <rect x="30" y="200" width="140" height="56" rx="8" class="box"/>
+  <text x="100" y="222" text-anchor="middle" class="label">SI unit</text>
+  <text x="100" y="240" text-anchor="middle" class="label-id">VIM 112-01-10</text>
+
+  <!-- species 2 -->
+  <rect x="200" y="200" width="140" height="56" rx="8" class="box"/>
+  <text x="270" y="222" text-anchor="middle" class="label">off-system unit</text>
+  <text x="270" y="240" text-anchor="middle" class="label-id">VIM 112-01-11</text>
+
+  <text x="270" y="295" text-anchor="middle" class="label-id">ISO 704 tree notation. Subordinate concepts inherit all</text>
+  <text x="270" y="311" text-anchor="middle" class="label-id">characteristics of the superordinate (genus-species).</text>
+</svg>

--- a/public/images/model/relations/partitive-complete.svg
+++ b/public/images/model/relations/partitive-complete.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 320" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive relation — complete decomposition</title>
+  <desc id="desc">ISO 704 rake notation. A comprehensive concept at the top is connected via a bracket rake to two partitive concepts. The backline ends with a tooth, indicating the encoded partitives fitted together constitute the comprehensive — no others exist.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .box-comp { fill: #ecfdf5; stroke: #047857; stroke-width: 2; }
+      .rake { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+    </style>
+  </defs>
+
+  <!-- background -->
+  <rect width="540" height="320" fill="#ffffff"/>
+
+  <!-- comprehensive concept (top) -->
+  <rect x="180" y="30" width="180" height="56" rx="8" class="box box-comp"/>
+  <text x="270" y="55" text-anchor="middle" class="label">measurement result</text>
+  <text x="270" y="73" text-anchor="middle" class="label-id">VIM 112-02-09</text>
+
+  <!-- rake: vertical backline from comp down, horizontal teeth to partitives -->
+  <!-- backline: from comp bottom (270,86) down to y=210 -->
+  <path d="M 270 86 L 270 210" class="rake"/>
+
+  <!-- tooth to partitive 1 (left): horizontal at y=210 from 270 to 130 -->
+  <path d="M 270 210 L 130 210 L 130 240" class="rake"/>
+
+  <!-- tooth to partitive 2 (right): horizontal at y=210 from 270 to 410 -->
+  <path d="M 270 210 L 410 210 L 410 240" class="rake"/>
+
+  <!-- "backline ends with a tooth" indicator — short vertical tail below the horizontal -->
+  <!-- (the last tooth IS at y=210; the backline ends here, signifying 'complete') -->
+  <text x="270" y="200" text-anchor="middle" class="label-note">completeness: complete</text>
+
+  <!-- partitive 1 (left) -->
+  <rect x="50" y="240" width="160" height="56" rx="8" class="box"/>
+  <text x="130" y="265" text-anchor="middle" class="label">measured quantity value</text>
+  <text x="130" y="283" text-anchor="middle" class="label-id">VIM 112-02-10</text>
+
+  <!-- partitive 2 (right) -->
+  <rect x="330" y="240" width="160" height="56" rx="8" class="box"/>
+  <text x="410" y="265" text-anchor="middle" class="label">measurement uncertainty</text>
+  <text x="410" y="283" text-anchor="middle" class="label-id">VIM 112-03-26</text>
+</svg>

--- a/public/images/model/relations/partitive-mixed-certainty.svg
+++ b/public/images/model/relations/partitive-mixed-certainty.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 340" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive relation — mixed per-partitive certainty</title>
+  <desc id="desc">Glossarist extension. A rake where two teeth are solid (certainty: confirmed) and one tooth is dashed (certainty: possible). ISO 704 notation alone cannot distinguish per-tooth uncertainty from set-level uncertainty.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .label-cert { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10px; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .box-comp { fill: #ecfdf5; stroke: #047857; stroke-width: 2; }
+      .box-possible { fill: #fef3c7; stroke: #92400e; stroke-width: 1.5; stroke-dasharray: 4 3; }
+      .rake { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+      .rake-possible { stroke: #92400e; stroke-width: 1.5; fill: none; stroke-dasharray: 4 3; }
+    </style>
+  </defs>
+
+  <rect width="540" height="340" fill="#ffffff"/>
+
+  <!-- comprehensive -->
+  <rect x="180" y="30" width="180" height="56" rx="8" class="box box-comp"/>
+  <text x="270" y="55" text-anchor="middle" class="label">system of quantities</text>
+  <text x="270" y="73" text-anchor="middle" class="label-id">VIM 112-01-03</text>
+
+  <!-- backline (solid) -->
+  <path d="M 270 86 L 270 210" class="rake"/>
+
+  <!-- confirmed teeth (solid) -->
+  <path d="M 270 210 L 100 210 L 100 240" class="rake"/>
+  <path d="M 270 210 L 270 210 L 270 240" class="rake"/>
+
+  <!-- possible tooth (dashed) -->
+  <path d="M 270 210 L 440 210 L 440 240" class="rake-possible"/>
+
+  <text x="270" y="200" text-anchor="middle" class="label-note">mixed certainty (Glossarist extension)</text>
+
+  <!-- confirmed partitive 1 -->
+  <rect x="30" y="240" width="140" height="56" rx="8" class="box"/>
+  <text x="100" y="262" text-anchor="middle" class="label">base quantity</text>
+  <text x="100" y="278" text-anchor="middle" class="label-id">VIM 112-01-04</text>
+  <text x="100" y="295" text-anchor="middle" class="label-cert" fill="#047857">confirmed</text>
+
+  <!-- confirmed partitive 2 -->
+  <rect x="200" y="240" width="140" height="56" rx="8" class="box"/>
+  <text x="270" y="262" text-anchor="middle" class="label">derived quantity</text>
+  <text x="270" y="278" text-anchor="middle" class="label-id">VIM 112-01-05</text>
+  <text x="270" y="295" text-anchor="middle" class="label-cert" fill="#047857">confirmed</text>
+
+  <!-- possible partitive -->
+  <rect x="370" y="240" width="140" height="56" rx="8" class="box-possible"/>
+  <text x="440" y="262" text-anchor="middle" class="label">quantity equation</text>
+  <text x="440" y="278" text-anchor="middle" class="label-id">VIM 112-01-22</text>
+  <text x="440" y="295" text-anchor="middle" class="label-cert" fill="#92400e">possible</text>
+</svg>

--- a/public/images/model/relations/partitive-notation-grid.svg
+++ b/public/images/model/relations/partitive-notation-grid.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 380" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive relation — all four diagram notation variants</title>
+  <desc id="desc">Four panels showing how ISO 704 rake notation combines with completeness and plurality markers: (1) complete, plain; (2) partial — backline continues without a tooth; (3) close-set double line at the receiver — type-shared plurality; (4) broken line — type-shared plurality is uncertain.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 13px; fill: #1f2937; }
+      .label-mini { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.2; }
+      .box-comp { fill: #ecfdf5; stroke: #047857; stroke-width: 1.5; }
+      .rake { stroke: #1f2937; stroke-width: 1.2; fill: none; }
+      .panel-title { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #1f2937; font-weight: 600; }
+    </style>
+  </defs>
+
+  <rect width="540" height="380" fill="#ffffff"/>
+
+  <!-- ============ Panel 1: complete, plain (top-left) ============ -->
+  <g transform="translate(10, 10)">
+    <text x="120" y="14" text-anchor="middle" class="panel-title">complete · plain</text>
+
+    <rect x="40" y="25" width="160" height="36" rx="6" class="box-comp"/>
+    <text x="120" y="48" text-anchor="middle" class="label">comprehensive</text>
+
+    <path d="M 120 61 L 120 110" class="rake"/>
+    <path d="M 120 110 L 60 110 L 60 135" class="rake"/>
+    <path d="M 120 110 L 180 110 L 180 135" class="rake"/>
+    <text x="120" y="100" text-anchor="middle" class="label-mini">backline ends with tooth</text>
+
+    <rect x="20" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="60" y="156" text-anchor="middle" class="label">part 1</text>
+    <rect x="140" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="180" y="156" text-anchor="middle" class="label">part 2</text>
+  </g>
+
+  <!-- ============ Panel 2: partial (top-right) ============ -->
+  <g transform="translate(280, 10)">
+    <text x="120" y="14" text-anchor="middle" class="panel-title">partial · backline continues</text>
+
+    <rect x="40" y="25" width="160" height="36" rx="6" class="box-comp"/>
+    <text x="120" y="48" text-anchor="middle" class="label">comprehensive</text>
+
+    <path d="M 120 61 L 120 150" class="rake"/>
+    <path d="M 120 110 L 60 110 L 60 135" class="rake"/>
+    <path d="M 120 110 L 180 110 L 180 135" class="rake"/>
+    <text x="135" y="142" class="label-mini">…others may exist</text>
+
+    <rect x="20" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="60" y="156" text-anchor="middle" class="label">part 1</text>
+    <rect x="140" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="180" y="156" text-anchor="middle" class="label">part 2</text>
+  </g>
+
+  <!-- ============ Panel 3: close-set double line (bottom-left) ============ -->
+  <g transform="translate(10, 200)">
+    <text x="120" y="14" text-anchor="middle" class="panel-title">close-set double line · type-shared plurality</text>
+
+    <rect x="40" y="25" width="160" height="36" rx="6" class="box-comp"/>
+    <text x="120" y="48" text-anchor="middle" class="label">comprehensive</text>
+
+    <path d="M 120 61 L 120 110" class="rake"/>
+    <!-- two parallel tooth lines (close-set) -->
+    <path d="M 120 110 L 60 110 L 60 135" class="rake"/>
+    <path d="M 120 110 L 180 110 L 180 135" class="rake"/>
+    <path d="M 120 106 L 60 106 L 60 135" class="rake"/>
+    <path d="M 120 106 L 180 106 L 180 135" class="rake"/>
+
+    <rect x="20" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="60" y="156" text-anchor="middle" class="label">part 1</text>
+    <rect x="140" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="180" y="156" text-anchor="middle" class="label">part 2</text>
+
+    <text x="120" y="180" text-anchor="middle" class="label-mini">several partitives of a given type are involved</text>
+  </g>
+
+  <!-- ============ Panel 4: broken line (bottom-right) ============ -->
+  <g transform="translate(280, 200)">
+    <text x="120" y="14" text-anchor="middle" class="panel-title">broken line · plurality uncertain</text>
+
+    <rect x="40" y="25" width="160" height="36" rx="6" class="box-comp"/>
+    <text x="120" y="48" text-anchor="middle" class="label">comprehensive</text>
+
+    <path d="M 120 61 L 120 110" class="rake"/>
+    <!-- dashed tooth lines (broken) -->
+    <path d="M 120 110 L 60 110 L 60 135" class="rake" stroke-dasharray="4 3"/>
+    <path d="M 120 110 L 180 110 L 180 135" class="rake" stroke-dasharray="4 3"/>
+
+    <rect x="20" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="60" y="156" text-anchor="middle" class="label">part 1</text>
+    <rect x="140" y="135" width="80" height="32" rx="6" class="box"/>
+    <text x="180" y="156" text-anchor="middle" class="label">part 2</text>
+
+    <text x="120" y="180" text-anchor="middle" class="label-mini">plurality is uncertain (qualifies the double-line claim)</text>
+  </g>
+</svg>

--- a/public/images/model/relations/partitive-partial.svg
+++ b/public/images/model/relations/partitive-partial.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 340" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive relation — partial decomposition</title>
+  <desc id="desc">ISO 704 rake notation, partial. The backline continues past the last tooth without ending — a trailing segment indicating one or more further partitive concepts exist that are not encoded.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .box-comp { fill: #ecfdf5; stroke: #047857; stroke-width: 2; }
+      .rake { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+    </style>
+  </defs>
+
+  <rect width="540" height="340" fill="#ffffff"/>
+
+  <!-- comprehensive -->
+  <rect x="180" y="30" width="180" height="56" rx="8" class="box box-comp"/>
+  <text x="270" y="55" text-anchor="middle" class="label">system of quantities</text>
+  <text x="270" y="73" text-anchor="middle" class="label-id">VIM 112-01-03</text>
+
+  <!-- backline from comp down — continues past last tooth (no end tooth) -->
+  <path d="M 270 86 L 270 250" class="rake"/>
+
+  <!-- three teeth — last one at y=210; backline continues to y=250 -->
+  <path d="M 270 160 L 90 160 L 90 200" class="rake"/>
+  <path d="M 270 185 L 270 185 L 270 185" class="rake"/>
+  <path d="M 270 160 L 270 160 L 270 160" class="rake"/>
+
+  <!-- leftmost tooth -->
+  <path d="M 270 145 L 90 145 L 90 200" class="rake"/>
+  <!-- middle tooth -->
+  <path d="M 270 175 L 270 175 L 270 200" class="rake"/>
+  <!-- right tooth -->
+  <path d="M 270 205 L 450 205 L 450 240" class="rake"/>
+
+  <!-- backline continuation past the last tooth (the "without a tooth" tail) -->
+  <path d="M 270 230 L 270 270" class="rake" stroke-dasharray="4 3"/>
+
+  <text x="290" y="262" class="label-note">… other partitives may exist</text>
+
+  <!-- partitive 1 -->
+  <rect x="20" y="200" width="140" height="50" rx="8" class="box"/>
+  <text x="90" y="222" text-anchor="middle" class="label">base quantity</text>
+  <text x="90" y="238" text-anchor="middle" class="label-id">VIM 112-01-04</text>
+
+  <!-- partitive 2 (middle - short tooth) -->
+  <rect x="200" y="200" width="140" height="50" rx="8" class="box"/>
+  <text x="270" y="222" text-anchor="middle" class="label">derived quantity</text>
+  <text x="270" y="238" text-anchor="middle" class="label-id">VIM 112-01-05</text>
+
+  <!-- partitive 3 -->
+  <rect x="380" y="240" width="140" height="50" rx="8" class="box"/>
+  <text x="450" y="262" text-anchor="middle" class="label">quantity equation</text>
+  <text x="450" y="278" text-anchor="middle" class="label-id">VIM 112-01-22</text>
+
+  <text x="270" y="110" text-anchor="middle" class="label-note">completeness: partial</text>
+</svg>

--- a/public/images/model/relations/partitive-shared-type.svg
+++ b/public/images/model/relations/partitive-shared-type.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 320" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive relation — type-shared plurality</title>
+  <desc id="desc">ISO 704 rake with close-set double line at the receiver end. Indicates several partitive concepts of a given type are involved. The double line is shown as two parallel strokes along the receiver side of the rake.</desc>
+
+  <defs>
+    <style>
+      .label { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; font-size: 14px; fill: #1f2937; }
+      .label-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #6b7280; }
+      .label-note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #6b7280; font-style: italic; }
+      .box { fill: #ffffff; stroke: #1f2937; stroke-width: 1.5; }
+      .box-comp { fill: #ecfdf5; stroke: #047857; stroke-width: 2; }
+      .rake { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+      .double-line { stroke: #1f2937; stroke-width: 1.5; fill: none; }
+    </style>
+  </defs>
+
+  <rect width="540" height="320" fill="#ffffff"/>
+
+  <!-- comprehensive -->
+  <rect x="180" y="30" width="180" height="56" rx="8" class="box box-comp"/>
+  <text x="270" y="55" text-anchor="middle" class="label">measurement result</text>
+  <text x="270" y="73" text-anchor="middle" class="label-id">VIM 112-02-09</text>
+
+  <!-- backline -->
+  <path d="M 270 86 L 270 210" class="rake"/>
+
+  <!-- teeth: TWO PARALLEL LINES at the receiver (close-set double line) -->
+  <!-- outer tooth line -->
+  <path d="M 270 210 L 130 210 L 130 240" class="double-line"/>
+  <path d="M 270 210 L 410 210 L 410 240" class="double-line"/>
+  <!-- inner parallel line, offset by 4px (close-set) -->
+  <path d="M 270 206 L 130 206 L 130 240" class="double-line"/>
+  <path d="M 270 206 L 410 206 L 410 240" class="double-line"/>
+
+  <text x="270" y="195" text-anchor="middle" class="label-note">plurality: is_shared = true (close-set double line)</text>
+
+  <!-- partitive 1 -->
+  <rect x="50" y="240" width="160" height="56" rx="8" class="box"/>
+  <text x="130" y="265" text-anchor="middle" class="label">measured quantity value</text>
+  <text x="130" y="283" text-anchor="middle" class="label-id">VIM 112-02-10</text>
+
+  <!-- partitive 2 -->
+  <rect x="330" y="240" width="160" height="56" rx="8" class="box"/>
+  <text x="410" y="265" text-anchor="middle" class="label">measurement uncertainty</text>
+  <text x="410" y="283" text-anchor="middle" class="label-id">VIM 112-03-26</text>
+</svg>

--- a/src/content/model/partitive-relations.mdx
+++ b/src/content/model/partitive-relations.mdx
@@ -26,6 +26,15 @@ PartitiveRelations live on the [`ManagedConcept`](/model/concepts#managedconcept
 
 All partitives within one PartitiveRelation are coordinate concepts: they share the comprehensive AND the criterion of subdivision.
 
+## Visual notation (ISO 704 rake)
+
+ISO 704 depicts partitive relations as a **rake** (or bracket): the comprehensive at the top, the backline descending, and teeth out to each partitive. The four variants below show how completeness and plurality combine.
+
+<figure>
+  <img src="/images/model/relations/partitive-notation-grid.svg" alt="Four ISO 704 rake notation variants: complete plain, partial with continuing backline, close-set double line for type-shared plurality, and broken line for uncertain plurality." loading="lazy" />
+  <figcaption>The four ISO 704 rake variants. Top row: completeness (complete vs partial). Bottom row: plurality markers (close-set double line vs broken line).</figcaption>
+</figure>
+
 ## When to use a PartitiveRelation vs. a binary edge
 
 | Shape | Use when … |
@@ -121,6 +130,11 @@ partitive_relations:
 
 A Glossarist extension: distinguish confirmed partitives from possible ones within one rake. Use case: "A is composed of `{b, c}` (sure of it) and `{d}` (might be, but there may be more)."
 
+<figure>
+  <img src="/images/model/relations/partitive-mixed-certainty.svg" alt="Rake with two solid teeth (confirmed) and one dashed tooth (possible). The dashed tooth connects to a yellow-outlined partitive box labeled 'possible'." loading="lazy" />
+  <figcaption>Per-partitive certainty. ISO 704 notation alone cannot distinguish "all teeth uncertain" from "only one tooth uncertain." Glossarist's <code>MemberCertainty</code> can.</figcaption>
+</figure>
+
 ```yaml
 partitive_relations:
   - comprehensive: { source: VIM, id: "1.3" }
@@ -187,6 +201,11 @@ partitive_relations:
         certainty: possible
     completeness: partial
 ```
+
+<figure>
+  <img src="/images/model/relations/external-concept-resolution.svg" alt="Two datasets side by side. Dataset A contains an ExternalConcept 'quantum field theory' with status: external. Dataset B contains a fully-defined concept with the same name. A provided_by arrow points from the ExternalConcept in A to the defining concept in B." loading="lazy" />
+  <figcaption>ExternalConcept resolution. The placeholder lives in Dataset A; the defining concept lives in Dataset B. The collection manager adds the <code>provided_by</code> edge when both datasets are loaded together.</figcaption>
+</figure>
 
 When another dataset defining `ext-qft` is loaded, the collection manager adds a `provided_by` binary edge from the ExternalConcept to the defining concept. Future references transparently resolve.
 

--- a/src/content/model/relationships.mdx
+++ b/src/content/model/relationships.mdx
@@ -58,6 +58,11 @@ related:
     content: "3.1.1.1.2"      # NTP: 3.1.1.1.2 is a part of this
 ```
 
+<figure>
+  <img src="/images/model/relations/binary-has-part.svg" alt="Two concept boxes connected by a labeled arrow. The left box 'bicycle' points to the right box 'wheel' via an arrow labeled 'has_part' (inverse: is_part_of)." loading="lazy" />
+  <figcaption>Binary partitive edge. Use for single pairwise assertions without completeness or plurality claims.</figcaption>
+</figure>
+
 ### Partitive relations (n-ary)
 
 When a partitive decomposition is *one-to-many* and the membership,
@@ -95,6 +100,16 @@ is performed. The `check-binary-has-part-redundancy` validator
 warns when binary `has_part` edges duplicate a PartitiveRelation's
 assertions. See [Partitive Relations](/model/partitive-relations)
 for the full model, YAML authoring, RDF emission, and validation rules.
+
+<figure>
+  <img src="/images/model/relations/generic-tree.svg" alt="ISO 704 generic-relation tree. A superordinate concept 'measurement unit' at the top branches down to 'SI unit' and 'off-system unit', with three dots indicating more specific concepts exist." loading="lazy" />
+  <figcaption>ISO 704 generic relation (genus-species). Tree notation distinguishes it from the partitive rake. A heavy starting line marks a separate terminological dimension; three dots indicate further species exist.</figcaption>
+</figure>
+
+<figure>
+  <img src="/images/model/relations/associative.svg" alt="Two concept boxes connected by a double-headed arrow labeled 'related_concept (associative)'." loading="lazy" />
+  <figcaption>ISO 704 / 10241-1 associative relation. Non-hierarchical thematic connection; all associative subtypes use this single double-headed arrow form.</figcaption>
+</figure>
 
 ### ExternalConcept resolution
 


### PR DESCRIPTION
## Summary

Adds 9 hand-drawn SVG diagrams depicting Glossarist's relationship
types using canonical ISO 704 notation. Wired into the model pages.

### Diagrams added

Under `public/images/model/relations/`:

| File | What it shows |
|------|---------------|
| `partitive-notation-grid.svg` | Four-panel overview: complete plain · partial · close-set double line · broken line |
| `partitive-complete.svg` | Full example: VIM measurement result → {measured value, uncertainty} |
| `partitive-partial.svg` | Full example: VIM system of quantities → {base, derived, equation} + backline continues |
| `partitive-shared-type.svg` | Close-set double line at receiver (is_shared: true) |
| `partitive-mixed-certainty.svg` | Glossarist extension: 2 solid teeth + 1 dashed tooth |
| `binary-has-part.svg` | Simple pairwise edge (bicycle → wheel) |
| `generic-tree.svg` | ISO 704 generic relation tree with heavy-line + three-dots |
| `associative.svg` | ISO 704 / 10241-1 double-headed arrow |
| `external-concept-resolution.svg` | ExternalConcept in Dataset A → provided_by → Dataset B |

All SVGs:
- Static (no JS)
- Accessible (`role="img"` + `<title>` + `<desc>`)
- Lazy-loaded
- Use the site's design tokens (system font stack, gray/green/amber palette)
- Render at any size via `viewBox`

### Wired into

- `src/content/model/partitive-relations.mdx` — notation grid at top, mixed-certainty figure, external-concept figure
- `src/content/model/relationships.mdx` — binary-has-part figure, generic-tree figure, associative figure

### Verification

- `npm run build` — 85 pages, no errors
- `npm test` — 214 tests pass, 0 failures

### Test plan

- [x] Build succeeds
- [x] All tests pass
- [x] SVGs have `role="img"` + `<title>` + `<desc>` for accessibility
- [x] No AI attribution
- [ ] Reviewer confirms ISO 704 notation is faithfully rendered
