### PR TITLE
docs: ISO 704:2022 partitive relations — MECE model page + blog post

### DIFF
--- a/src/content/blog/2026-07-23-partitive-relations-v2.mdx
+++ b/src/content/blog/2026-07-23-partitive-relations-v2.mdx
@@ -8,6 +8,12 @@ date: 2026-07-23
 
 {/* byline rendered by BlogLayout */}
 
+> **Update 2026-07-29 — superseded by ISO 704:2022 MECE model.**
+> The TypeSharedPlurality + MemberCertainty design described here has
+> been replaced by the MECE presence/count decomposition (ISO 704:2022
+> §5.5.4.3). See [ISO 704:2022 partitive relations](/blog/2026-07-29-iso704-2022-partitive-relations)
+> for the current model. This post is preserved as the historical record.
+
 Today we're shipping the **`PartitiveRelation`** redesign — an ISO-aligned replacement for the `PartitiveHyperedge` model we shipped [yesterday](/blog/2026-07-22-partitive-hyperedges). Yesterday's design worked end-to-end but had three architectural problems that surfaced under review. Today's v2 fixes them.
 
 If you're already using v1 PartitiveHyperedges, the [migration script](https://github.com/glossarist/concept-model/blob/main/exe/migrate-to-partitive-relation-v2) is one command. The wire format changes; the data survives.

--- a/src/content/blog/2026-07-29-iso704-2022-partitive-relations.mdx
+++ b/src/content/blog/2026-07-29-iso704-2022-partitive-relations.mdx
@@ -1,0 +1,132 @@
+---
+title: "ISO 704:2022 partitive relations — MECE multiplicity, delimiting parts, and ExternalConcept"
+description: "Glossarist now implements ISO 704:2022 partitive relations with the full per-member multiplicity model (presence x count as orthogonal MECE dimensions), delimiting parts, completeness claims, subdivision criterion, and first-class ExternalConcept support with provided_by resolution. The optomechanical mouse canonical example demonstrates all features."
+authors:
+  - Ribose
+date: 2026-07-29
+---
+
+{/* byline rendered by BlogLayout */}
+
+Today we're announcing full [ISO 704:2022](https://www.iso.org/standard/38109.html) partitive relation support in Glossarist. This is the third iteration of the partitive model — each version has been informed by real-world use and feedback from the glossarist-ruby, glossarist-js, and concept-browser teams. The result is a model that faithfully implements the standard while remaining practical for tooling.
+
+## What changed
+
+The headline feature is the **MECE multiplicity decomposition**. ISO 704:2022 uses diagram line notation to express per-member multiplicity: solid vs dashed lines for presence, single vs double lines for count, bold (3x-width) for delimiting parts. Glossarist now encodes all three as structured data fields rather than opaque strings.
+
+## The MECE model: presence x count
+
+ISO 704:2022 distinguishes five multiplicity types using combinations of two orthogonal axes:
+
+- **Presence**: `required` (must exist) or `optional` (may exist)
+- **Count**: `exactly_one`, `at_least_one`, or `multiple`
+
+That's 6 combinations, 5 valid. The invalid one (`optional + at_least_one`) is rejected because if a part is optional, the at-least-one constraint is vacuous — it collapses to `(optional, multiple)`.
+
+| Presence | Count | Visual | ISO 704 name |
+|----------|-------|--------|--------------|
+| required | exactly_one | 1 solid | compulsory |
+| optional | exactly_one | 1 dashed | optional |
+| required | multiple | 2 solid | compulsory multiple |
+| optional | multiple | 2 dashed | optional multiple |
+| required | at_least_one | 1 solid + 1 dashed | compulsory at-least-one |
+
+This decomposition is **DRY** (2+3=5 values instead of a flat 5-value enum), **MECE** (every combination is valid or explicitly invalid), and **OCP-compliant** (adding a new count type is additive — no existing values change).
+
+### Delimiting parts
+
+A **delimiting part** (ISO 704:2022 bold 3x-width line) behaves like a delimiting characteristic: it distinguishes the comprehensive from coordinate concepts. This is the third orthogonal dimension on each `PartitiveMember`.
+
+## The optomechanical mouse
+
+ISO 704:2022 §5.5.4.2.2 uses "optomechanical mouse" as its canonical worked example. Here it is in Glossarist:
+
+```yaml
+partitive_relations:
+  - comprehensive: { source: EXAMPLE, id: "optomechanical-mouse" }
+    partitives:
+      - ref: { source: EXAMPLE, id: "mouse-ball" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "x-axis-roller" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "y-axis-roller" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "infrared-emitter" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "infrared-sensor" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "circuit-board" }
+      - ref: { source: EXAMPLE, id: "mouse-button" }
+      - ref: { source: EXAMPLE, id: "mouse-wheel" }
+        presence: optional
+    completeness: complete
+    criterion:
+      eng: physical component decomposition
+```
+
+Key observations from this example:
+
+- **Five delimiting parts** (mouse ball, two rollers, IR emitter, IR sensor) — these distinguish "optomechanical mouse" from coordinate concepts "mechanical mouse" and "optical mouse".
+- **Mouse wheel is optional** (`presence: optional`) — not found on all optomechanical mice.
+- **Mouse button is not delimiting** — all computer mice have buttons, so it doesn't help distinguish.
+- **Completeness: complete** — this is the full decomposition.
+
+## ExternalConcept support
+
+Sometimes you know a concept is a partitive but can't define it yourself — it lives in another dataset. ISO 704:2022 calls these "parenthetic terms"; we use the semantic name **ExternalConcept**.
+
+An ExternalConcept is a ManagedConcept with `status: external` and minimal data (just a designation). When another dataset defining the concept is loaded, the collection manager adds a `provided_by` binary edge:
+
+```yaml
+# Dataset A: the ExternalConcept (placeholder)
+id: ext-qft
+status: external
+data:
+  identifier: ext-qft
+  designations:
+    - designation: "quantum field theory"
+
+# After Dataset B is loaded and matched:
+related:
+  - type: provided_by
+    ref: { source: urn:dataset-b, id: "qft" }
+```
+
+Dataset B is untouched. The edge lives on the ExternalConcept in Dataset A.
+
+## What else is new
+
+- **Subdivision criterion** (Glossarist extension) — ISO 12620's coordinate-concept coherence: partitives within one relation share the comprehensive AND the criterion. Two relations with the same comprehensive but different criteria are distinct decompositions (e.g., bicycle-by-physical-structure vs bicycle-by-functional-subsystem).
+- **Completeness** — whether the encoded partitives are ALL the parts (`complete`, default) or only SOME (`partial`).
+- **10 Ruby validators** covering schema validation, enum drift, SHACL coverage, JSON-LD context completeness, LUTAML reference resolution, PartitiveRelation coherence, ExternalConcept shape, and binary-has-part redundancy.
+- **35 RSpec specs** including MECE coverage tests that verify all 5 valid presence/count combinations are exercised.
+
+## What was dropped
+
+The earlier TypeSharedPlurality and MemberCertainty designs (from the initial PartitiveRelation v2 announcement) have been replaced by the MECE presence/count model. The flat `Multiplicity` enum has been decomposed into its orthogonal factors. The `content` field was removed — structural edges don't carry prose.
+
+## Cross-repo status
+
+| Repo | Status |
+|------|--------|
+| [concept-model](https://github.com/glossarist/concept-model) | Shipped. Full ISO 704:2022 model with MECE decomposition, 10 validators, 35 specs. |
+| [glossarist-ruby](/docs/software/glossarist-ruby) | In progress. PartitiveRelation model, RDF emission, validator rule. |
+| [glossarist-js](/docs/software/glossarist-js) | Shipped. PartitiveMember with presence/count/is_delimiting, construction-time validation, `multiplicityFromPair` utility. |
+| [concept-browser](/docs/software/concept-browser) | Planned. PartitiveRelationList rendering with delimiting-part badges. |
+
+## Prior iterations
+
+1. **v1 — PartitiveHyperedge** (2026-07-22): flat enumeration + diagram-notation markers. Announced [here](/blog/2026-07-22-partitive-hyperedges) (superseded).
+2. **v2 — PartitiveRelation** (2026-07-23): ISO-aligned rename, criterion field, ExternalConcept, provides/provided_by. Announced [here](/blog/2026-07-23-partitive-relations-v2) (superseded).
+3. **v3 — ISO 704:2022 MECE** (today): presence/count decomposition, delimiting parts, `multiplicityFromPair` utility.
+
+Each iteration was informed by real-world use and inter-repo design feedback. The final model is stable and aligns with both the standard and practical tooling needs.
+
+## Further reading
+
+- [Partitive Relations](/model/partitive-relations) — full model reference with the optomechanical mouse example
+- [Relationships](/model/relationships) — binary typed relationships (54 types)
+- [Concepts](/model/concepts) — ManagedConcept, LocalizedConcept, and ExternalConcept
+- [ISO 704:2022](https://www.iso.org/standard/38109.html) — Terminology work — Principles and methods
+- [ISO 12620](https://www.iso.org/standard/56034.html) — Terminology and other language and content resources
+- [glossarist-js](/docs/software/glossarist-js) — JavaScript SDK with multiplicityFromPair utility

--- a/src/content/model/partitive-relations.mdx
+++ b/src/content/model/partitive-relations.mdx
@@ -1,100 +1,116 @@
 ---
 title: Partitive Relations
-description: ISO 704 / 1087-1 / 12620 partitive relations — one-to-many decompositions with completeness, type-shared plurality, per-partitive certainty, and subdivision criterion
+description: "ISO 704:2022 partitive relations — one-to-many decompositions with MECE presence/count, delimiting parts, completeness, and subdivision criterion"
 ---
 
 # Partitive Relations
 
-A **`PartitiveRelation`** is an [ISO 704](https://www.iso.org/standard/38109.html) / [ISO 1087-1](https://www.iso.org/standard/56528.html) / [ISO 12620](https://www.iso.org/standard/56034.html) partitive relation: one comprehensive concept (the whole) is related to two or more partitive concepts (the parts) as a *single relationship*. The partitives fitted together constitute the comprehensive. It captures invariants that binary [`has_part`](/model/relationships#hierarchical-relationships) / `is_part_of` edges cannot:
+A **`PartitiveRelation`** implements [ISO 704:2022](https://www.iso.org/standard/38109.html) §5.5.4 partitive relations: one comprehensive concept (the whole) is related to two or more partitive concepts (the parts) which fitted together constitute the comprehensive. It captures invariants that binary [`has_part`](/model/relationships#hierarchical-relationships) / `is_part_of` edges cannot:
 
 - **Set membership** — which comprehensive owns which parts, as one rake rather than N independent binary edges
+- **Per-member multiplicity** — ISO 704:2022 presence (required/optional) and count (exactly-one/at-least-one/multiple) as structured data
+- **Delimiting parts** — parts that behave like delimiting characteristics, distinguishing the comprehensive from coordinate concepts
 - **Completeness** — whether the encoded partitives fitted together constitute the comprehensive (`complete`) or only some of it (`partial`)
-- **Type-shared plurality** — ISO 704's close-set double line and broken line notation, encoded as structured data
-- **Per-partitive certainty** — a Glossarist extension distinguishing "confirmed" partitives from "possible" ones within one rake
 - **Subdivision criterion** — ISO 12620's coordinate-concept coherence: partitives within one relation share a criterion
 
 PartitiveRelations live on the [`ManagedConcept`](/model/concepts#managedconcept) (concept level, alongside `related`), not on its data payload.
 
-## ISO terminology
+## ISO 704:2022 terminology
 
-| Role | ISO 12620 name |
-|------|---------------|
-| The whole concept | superordinate concept partitive |
-| Each part concept | subordinate concept partitive |
-| The relation itself | partitive relation |
-| Siblings within one rake | coordinate concepts |
+| Role | ISO term |
+|------|----------|
+| The whole concept | comprehensive concept (superordinate concept partitive) |
+| Each part concept | partitive concept (subordinate concept partitive) |
+| The relation | partitive relation |
+| Siblings in one rake | coordinate concepts |
 
-All partitives within one PartitiveRelation are coordinate concepts: they share the comprehensive AND the criterion of subdivision.
+All partitives within one PartitiveRelation are **coordinate concepts** (ISO 12620): they share the comprehensive AND the criterion of subdivision.
 
-## Visual notation (ISO 704 rake)
+## The MECE multiplicity model
 
-ISO 704 depicts partitive relations as a **rake** (or bracket): the comprehensive at the top, the backline descending, and teeth out to each partitive. The four variants below show how completeness and plurality combine.
+ISO 704:2022 encodes per-member multiplicity via diagram line notation. Glossarist decomposes this into two orthogonal dimensions:
 
-<figure>
-  <img src="/images/model/relations/partitive-notation-grid.svg" alt="Four ISO 704 rake notation variants: complete plain, partial with continuing backline, close-set double line for type-shared plurality, and broken line for uncertain plurality." loading="lazy" />
-  <figcaption>The four ISO 704 rake variants. Top row: completeness (complete vs partial). Bottom row: plurality markers (close-set double line vs broken line).</figcaption>
-</figure>
+- **Presence**: `required` (must exist in every instance) or `optional` (exists in some instances only)
+- **Count**: `exactly_one`, `at_least_one`, or `multiple`
+
+Plus a third orthogonal flag: **is_delimiting** (boolean) — whether this part is a delimiting part.
+
+### Valid combinations (6 total, 5 valid)
+
+| Presence | Count | ISO 704 visual | ISO 704 name |
+|----------|-------|----------------|--------------|
+| required | exactly_one | 1 solid line | compulsory |
+| optional | exactly_one | 1 dashed line | optional |
+| required | multiple | 2 solid lines | compulsory multiple |
+| optional | multiple | 2 dashed lines | optional multiple |
+| required | at_least_one | 1 solid + 1 dashed | compulsory at-least-one |
+| optional | at_least_one | **INVALID** — collapses to optional multiple | — |
+
+The invalid combination (`optional + at_least_one`) is rejected: if a part is optional, the at-least-one constraint is vacuous (the part may not exist at all), so it collapses to `(optional, multiple)`. Both the JSON Schema and the Ruby validator enforce this with a clear error message.
+
+### Delimiting parts (ISO 704:2022 §5.5.4.2.2)
+
+A **delimiting part** behaves like a delimiting characteristic: it distinguishes the comprehensive from coordinate concepts. In ISO 704 diagrams, delimiting parts are drawn with a bold (3x-width) line.
+
+**Canonical example** (ISO 704:2022 §5.5.4.2.2): for "optomechanical mouse":
+
+| Part | Delimiting? | Why? |
+|------|-------------|------|
+| mouse ball | yes | distinguishes from optical mice |
+| x-axis roller | yes | distinguishes from optical mice |
+| y-axis roller | yes | distinguishes from optical mice |
+| infrared emitter | yes | distinguishes from mechanical mice |
+| infrared sensor | yes | distinguishes from mechanical mice |
+| circuit board | no | all mice have circuit boards |
+| mouse button | no | all computer mice have buttons |
+| mouse wheel | no | not found on all optomechanical mice (optional) |
+
+Delimiting is **orthogonal** to presence and count — a delimiting part can be compulsory, optional, or any other multiplicity.
 
 ## When to use a PartitiveRelation vs. a binary edge
 
 | Shape | Use when … |
 |-------|------------|
-| Binary `has_part` / `is_part_of` | The relationship is pairwise and needs no completeness or plurality metadata |
-| `PartitiveRelation` | The relationship is one-to-many with completeness claims, type-shared plurality, per-partitive certainty, or subdivision criterion |
+| Binary `has_part` / `is_part_of` | The relationship is pairwise and needs no multiplicity, delimiting, or completeness metadata |
+| `PartitiveRelation` | The relationship is one-to-many with multiplicity, delimiting parts, completeness claims, or subdivision criterion |
 
-Both shapes coexist on the same concept — no automatic consolidation is performed. The `check-binary-has-part-redundancy` validator warns when binary `has_part` edges duplicate a PartitiveRelation's assertions.
-
-ISO 704 requires partitive relations to have **two or more** partitives. A single partitive should be expressed as a binary `has_part` edge instead.
+Both shapes coexist. ISO 704 requires **two or more** partitives per relation. A single partitive should be a binary `has_part` edge.
 
 ## Model
 
 ```
 PartitiveRelation
-  +comprehensive: ConceptRef [1]                // superordinate concept partitive
-  +partitives:    PartitiveMember [2..*]        // subordinate concepts partitive
-  +completeness:  Completeness [0..1]           // default: complete
-  +plurality:     TypeSharedPlurality [0..1]    // optional
-  +criterion:     LocalizedString [0..1]        // subdivision criterion
+  +comprehensive: ConceptRef [1]              // the whole
+  +partitives:    PartitiveMember [2..*]      // the parts
+  +completeness:  Completeness [0..1]         // default: complete
+  +criterion:     LocalizedString [0..1]      // subdivision criterion (Glossarist extension)
 
-PartitiveMember
-  +ref:           ConceptRef [1]                // the partitive concept
-  +certainty:     MemberCertainty [0..1]        // default: confirmed
-
-TypeSharedPlurality
-  +is_shared:     Boolean [1..1]                // ISO 704 close-set double line
-  +is_uncertain:  Boolean [0..1]                // ISO 704 broken line
-  +shared_type:   ConceptRef [0..1]             // Glossarist extension
+PartitiveMember (three orthogonal dimensions)
+  +ref:           ConceptRef [1]              // the partitive concept
+  +presence:      PartitivePresence [0..1]    // default: required
+  +count:         PartitiveCount [0..1]       // default: exactly_one
+  +is_delimiting: Boolean [0..1]             // default: false
 ```
 
 Wired into `ManagedConcept` as `+partitive_relations: PartitiveRelation [0..*]`.
 
 ### Completeness
 
-Two values, SSOT-loaded from the [completeness SKOS taxonomy](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/completeness.ttl):
+- **`complete`** *(default)* — the encoded partitives fitted together constitute the comprehensive. No further partitives exist.
+- **`partial`** — the encoded partitives are some of the comprehensive's partitives; others exist but are not encoded.
 
-- **`complete`** *(default)* — the encoded partitives fitted together constitute the comprehensive. The backline ends with a tooth; no further partitives exist.
-- **`partial`** — the encoded partitives are some of the partitives of the comprehensive; others exist but are not encoded. The backline continues without a tooth.
+### PartitivePresence (ISO 704:2022)
 
-### MemberCertainty
+- **`required`** *(default)* — must exist in every instance. ISO 704: solid line.
+- **`optional`** — exists in some instances only. ISO 704: dashed line.
 
-Two values, SSOT-loaded from the [member-certainty SKOS taxonomy](https://github.com/glossarist/concept-model/blob/main/ontologies/taxonomies/member-certainty.ttl):
+### PartitiveCount (ISO 704:2022)
 
-- **`confirmed`** *(default)* — this partitive is definitely a member of the decomposition.
-- **`possible`** — this partitive may or may not be a member. Used when sources disagree, identification is provisional, or the source diagram's broken line applied to this tooth.
-
-MemberCertainty is a Glossarist extension beyond ISO 704 notation, which only supports set-level plurality uncertainty.
-
-### TypeSharedPlurality
-
-Encodes ISO 704's diagram notation as structured data (not as opaque strings):
-
-- **`is_shared`** *(required)* — ISO 704 close-set double line. True when several partitive concepts of a given type are involved. Distinct from cardinality alone: three partitives of different types do not satisfy this; three partitives of the same type do.
-- **`is_uncertain`** — ISO 704 broken line. True when the type-shared plurality is uncertain. Requires `is_shared: true` for semantic coherence.
-- **`shared_type`** *(optional)* — Glossarist extension. The type the partitives share, when known. ISO notation does not encode this; it is left for the reader to infer.
+- **`exactly_one`** *(default)* — exactly one instance. ISO 704: single line.
+- **`at_least_one`** — one or more must exist. ISO 704: 1 solid + 1 dashed. Only valid with `presence: required`.
+- **`multiple`** — two or more instances. ISO 704: double line.
 
 ## YAML authoring
-
-PartitiveRelations live under the top-level `partitive_relations` key on a managed concept:
 
 ```yaml
 termid: "112-02-09"
@@ -105,192 +121,99 @@ partitive_relations:
       source: VIM
       id: "112-02-09"
     partitives:
-      - ref: { source: VIM, id: "112-02-10" }   # measured quantity value
-      - ref: { source: VIM, id: "112-03-26" }   # measurement uncertainty
+      - ref: { source: VIM, id: "112-02-10" }
+      - ref: { source: VIM, id: "112-03-26" }
     completeness: complete
-    plurality:
-      is_shared: true
     criterion:
       eng: measurement result composition
 ```
 
-### Minimal (plain complete)
+### ISO 704:2022 optomechanical mouse example
 
-When `completeness` is omitted, the schema default (`complete`) applies. Plurality defaults to absent. `certainty` on each member defaults to `confirmed`.
-
-```yaml
-partitive_relations:
-  - comprehensive: { source: VIM, id: "1.1" }
-    partitives:
-      - ref: { source: VIM, id: "1.2" }
-      - ref: { source: VIM, id: "1.3" }
-```
-
-### Mixed per-partitive certainty
-
-A Glossarist extension: distinguish confirmed partitives from possible ones within one rake. Use case: "A is composed of `{b, c}` (sure of it) and `{d}` (might be, but there may be more)."
-
-<figure>
-  <img src="/images/model/relations/partitive-mixed-certainty.svg" alt="Rake with two solid teeth (confirmed) and one dashed tooth (possible). The dashed tooth connects to a yellow-outlined partitive box labeled 'possible'." loading="lazy" />
-  <figcaption>Per-partitive certainty. ISO 704 notation alone cannot distinguish "all teeth uncertain" from "only one tooth uncertain." Glossarist's <code>MemberCertainty</code> can.</figcaption>
-</figure>
+The canonical worked example from ISO 704:2022 §5.5.4.2.2:
 
 ```yaml
 partitive_relations:
-  - comprehensive: { source: VIM, id: "1.3" }
+  - comprehensive: { source: EXAMPLE, id: "optomechanical-mouse" }
     partitives:
-      - ref: { source: VIM, id: "1.4" }
-        certainty: confirmed
-      - ref: { source: VIM, id: "1.5" }
-        certainty: confirmed
-      - ref: { source: VIM, id: "1.22" }
-        certainty: possible
-    completeness: partial
+      - ref: { source: EXAMPLE, id: "mouse-ball" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "x-axis-roller" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "y-axis-roller" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "infrared-emitter" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "infrared-sensor" }
+        is_delimiting: true
+      - ref: { source: EXAMPLE, id: "circuit-board" }
+      - ref: { source: EXAMPLE, id: "mouse-button" }
+      - ref: { source: EXAMPLE, id: "mouse-wheel" }
+        presence: optional
+    completeness: complete
     criterion:
-      eng: quantity classification
+      eng: physical component decomposition
 ```
+
+Mouse wheel has `presence: optional` (not found on all optomechanical mice). The five delimiting parts distinguish "optomechanical mouse" from coordinate concepts "mechanical mouse" and "optical mouse".
 
 ### Two decompositions of the same comprehensive
 
-ISO 12620's coordinate-concept coherence: partitives within one relation share the comprehensive AND the criterion of subdivision. Two relations on the same comprehensive with different criteria are distinct decompositions.
-
 ```yaml
 partitive_relations:
-  - comprehensive: { source: EXAMPLE, id: "116-01-01" }
+  - comprehensive: { source: EXAMPLE, id: "bicycle" }
     partitives:
-      - ref: { source: EXAMPLE, id: "116-01-02" }
-      - ref: { source: EXAMPLE, id: "116-01-03" }
+      - ref: { source: EXAMPLE, id: "frame" }
+      - ref: { source: EXAMPLE, id: "wheels" }
     completeness: complete
     criterion: { eng: physical structure }
-  - comprehensive: { source: EXAMPLE, id: "116-01-01" }
+  - comprehensive: { source: EXAMPLE, id: "bicycle" }
     partitives:
-      - ref: { source: EXAMPLE, id: "116-01-04" }
-      - ref: { source: EXAMPLE, id: "116-01-05" }
+      - ref: { source: EXAMPLE, id: "structural" }
+      - ref: { source: EXAMPLE, id: "propulsion" }
     completeness: complete
     criterion: { eng: functional subsystem }
 ```
 
-The coherence validator rejects two relations with identical `(comprehensive, criterion)` as duplicates.
+The coherence validator rejects duplicate `(comprehensive, criterion)` pairs as errors.
 
-### Cross-dataset partitives
-
-Partitives and comprehensive can reference concepts in other datasets using the same `source` + `id` shape as binary relationships:
-
-```yaml
-partitive_relations:
-  - comprehensive:
-      source: urn:oiml:pub:v:2-200:2012
-      id: "2.9"
-    partitives:
-      - ref:
-          source: urn:oiml:pub:v:1:1993
-          id: "2.10"
-```
-
-## ExternalConcept support
-
-A partitive can reference an [ExternalConcept](/model/concepts#externalconcept) — a ManagedConcept with `status: external` that lives in this dataset but is defined elsewhere. Use case: "we know X is a partitive, but we don't define X ourselves; it lives in another dataset."
+### ExternalConcept partitive
 
 ```yaml
 partitive_relations:
   - comprehensive: { source: EXAMPLE, id: "114-01-01" }
     partitives:
       - ref: { source: EXAMPLE, id: "114-01-02" }
-        certainty: confirmed
       - ref: { source: EXAMPLE, id: "ext-qft" }   # ExternalConcept
-        certainty: possible
+        presence: optional
     completeness: partial
 ```
 
-<figure>
-  <img src="/images/model/relations/external-concept-resolution.svg" alt="Two datasets side by side. Dataset A contains an ExternalConcept 'quantum field theory' with status: external. Dataset B contains a fully-defined concept with the same name. A provided_by arrow points from the ExternalConcept in A to the defining concept in B." loading="lazy" />
-  <figcaption>ExternalConcept resolution. The placeholder lives in Dataset A; the defining concept lives in Dataset B. The collection manager adds the <code>provided_by</code> edge when both datasets are loaded together.</figcaption>
-</figure>
-
-When another dataset defining `ext-qft` is loaded, the collection manager adds a `provided_by` binary edge from the ExternalConcept to the defining concept. Future references transparently resolve.
-
 ## RDF emission
 
-Each relation emits one `gloss:PartitiveRelation` subject, anchored to the carrying concept via `gloss:hasPartitiveRelation`. Each partitive is a `gloss:PartitiveMember` with `gloss:ref` (ConceptRef) and optional `gloss:certainty`:
-
 ```turtle
-<concept/112-02-09> gloss:hasPartitiveRelation [
+<concept/optomechanical-mouse> gloss:hasPartitiveRelation [
   a gloss:PartitiveRelation ;
-  gloss:comprehensive <concept/112-02-09> ;
+  gloss:comprehensive <concept/optomechanical-mouse> ;
   gloss:hasPartitive
-    [ a gloss:PartitiveMember ; gloss:ref <concept/112-02-10> ] ,
-    [ a gloss:PartitiveMember ; gloss:ref <concept/112-03-26> ] ;
+    [ a gloss:PartitiveMember ; gloss:ref <concept/mouse-ball> ; gloss:isDelimiting true ] ,
+    [ a gloss:PartitiveMember ; gloss:ref <concept/mouse-wheel> ; gloss:presence <partitivePresence/optional> ] ;
   gloss:completeness <completeness/complete> ;
-  gloss:hasPlurality [
-    a gloss:TypeSharedPlurality ;
-    gloss:isShared true ;
-  ] ;
-  gloss:criterion "measurement result composition"@en ;
+  gloss:criterion "physical component decomposition"@en ;
 ] .
 ```
 
-Completeness and certainty serialize as `skos:Concept` references into the corresponding taxonomies (not as xsd:string literals), matching the SHACL `sh:valuesFrom` pattern used by every other enum in the model. The `criterion` field uses language-tagged literals (`@container: @language` in JSON-LD).
-
 ## Validation
 
-Shape checks live in the validator framework, not in the model constructor:
-
-- **`comprehensive`** must be a non-empty `ConceptRef`
-- **`partitives`** must contain at least two `PartitiveMember` instances (ISO 704 requirement)
-- **`completeness`** values must be in `COMPLETENESS_VALUES`
-- **`certainty`** values on each partitive must be in `MEMBER_CERTAINTY_VALUES`
-- **No duplicate decompositions**: two relations on the same comprehensive with the same criterion are flagged as duplicates
-- **Plurality coherence**: `is_uncertain: true` requires `is_shared: true` (ISO 704's broken line qualifies the close-set double line plurality claim)
-
-### Ownership invariant
-
-A soft `sh:Warning` SHACL constraint (`gloss:PartitiveRelationOwnershipShape`) flags relations whose carrying concept is not the comprehensive — useful for catching accidental cross-references without blocking legitimate indexing patterns.
-
-### ExternalConcept coherence
-
-A separate SHACL warning shape (`gloss:ExternalConceptCoherenceShape`) flags external concepts that carry a definition or sources — those would contradict `status: external`.
-
-In Ruby, this is `Glossarist::Validation::Rules::PartitiveRelationRule` (rule code `GLS-221`). In JS, it's `PartitiveRelationShapeRule`. Both auto-register with the default validator chain.
-
-## Standards alignment
-
-PartitiveRelations are Glossarist's implementation of ISO 704 / ISO 1087-1 / ISO 12620 partitive relations. The binary `broader_partitive` / `narrower_partitive` types continue to map directly to `iso-thes:broaderPartitive` / `iso-thes:narrowerPartitive`; the n-ary relation has no direct SKOS equivalent and serializes as a `gloss:PartitiveRelation` blank node or named node.
-
-Glossarist extensions beyond ISO notation:
-
-- **MemberCertainty** (per-partitive confirmed/possible) — ISO notation only supports set-level plurality uncertainty
-- **TypeSharedPlurality.shared_type** — ISO notation marks "of a given type" visually but does not encode which type
-- **criterion as structured data** — ISO mentions criterion in the coordinate-concept definition but does not encode it
-
-## Migrating from v1 `PartitiveHyperedge`
-
-The v2 design renames `PartitiveHyperedge` → `PartitiveRelation` and restructures the fields. Run the migration script:
-
-```bash
-bundle exec exe/migrate-to-partitive-relation-v2 --dry-run path/to/concepts/
-# review, then:
-bundle exec exe/migrate-to-partitive-relation-v2 --backup path/to/concepts/
-```
-
-| v1 field | v2 field | Notes |
-|----------|----------|-------|
-| `partitive_hyperedges` (top-level key) | `partitive_relations` | renamed |
-| `parts: [ConceptRef]` | `partitives: [{ref: ConceptRef, certainty?: MemberCertainty}]` | restructured |
-| `enumeration: closed` | `completeness: complete` | renamed |
-| `enumeration: open` | `completeness: partial` | renamed |
-| `markers: [double]` | `plurality: {is_shared: true}` | data not notation |
-| `markers: [dashed]` | `plurality: {is_uncertain: true}` | data not notation |
-| `markers: [double, dashed]` | `plurality: {is_shared: true, is_uncertain: true}` | both |
-| `content` (any) | *(dropped)* | moved to LocalizedConcept notes; structural edges don't carry prose |
-
-Lossy cases (rare) are flagged for human review.
+- **`comprehensive`** must be a non-empty ConceptRef
+- **`partitives`** must have >= 2 members (ISO 704 requirement)
+- **Invalid MECE combo**: `presence: optional + count: at_least_one` is rejected with a clear error
+- **No duplicates**: two relations on the same comprehensive with the same criterion are flagged
+- **Delimiting + optional warning**: a delimiting part that is optional is semantically incoherent (a warning, not an error)
 
 ## See also
 
 - [Relationships](/model/relationships) — binary typed relationships (54 types including `provides` / `provided_by`)
-- [Concepts](/model/concepts) — `ManagedConcept`, `LocalizedConcept`, and `ExternalConcept`
-- [Datasets & Sections](/model/datasets) — where PartitiveRelations live in the dataset layout
-- [Concept model v3.2 release notes](https://github.com/glossarist/concept-model/blob/main/RELEASE_NOTES.md) — full release notes
-- [ISO 704](https://www.iso.org/standard/38109.html) — Terminology work — Principles and methods
-- [ISO 1087-1](https://www.iso.org/standard/56528.html) — Terminology work — Vocabulary
+- [Concepts](/model/concepts) — ManagedConcept, LocalizedConcept, and ExternalConcept
+- [ISO 704:2022](https://www.iso.org/standard/38109.html) — Terminology work — Principles and methods
 - [ISO 12620](https://www.iso.org/standard/56034.html) — Terminology and other language and content resources


### PR DESCRIPTION
## Summary

Full rewrite of the Partitive Relations model page for the final
ISO 704:2022 MECE model, plus a new blog post announcing the feature.

### What changed

- **Model page** (`partitive-relations.mdx`): complete rewrite for the
  MECE presence/count/is_delimiting model. Includes the canonical
  optomechanical mouse example from ISO 704:2022 §5.5.4.3.1, the
  full 6-combination mapping table, ExternalConcept support, and
  updated YAML/RDF examples.
- **Blog post** (`2026-07-29-iso704-2022-partitive-relations.mdx`):
  announces ISO 704:2022 support with the MECE decomposition,
  delimiting parts, the mouse example, ExternalConcept, cross-repo
  status, and the v1→v2→v3 iteration history.
- **v2 blog post** (`2026-07-23-partitive-relations-v2.mdx`):
  superseded banner pointing to the new announcement.

### Verification

- `npm run build` — 86 pages, no errors
- `npm test` — 214 tests pass

### Test plan

- [x] Build succeeds
- [x] All tests pass
- [x] No AI attribution
