### PR TITLE
docs: canonical + fictitious hyperedge SVG diagrams

### DIFF
--- a/public/images/hyperedge-bicycle.svg
+++ b/public/images/hyperedge-bicycle.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive hyperedge — fictitious example: bicycle by physical structure</title>
+  <desc id="desc">A bicycle comprehensive concept at the top. Nine parts drop from a shared backline. Frame, wheel, and handlebar are delimiting (bold 3x-width lines) — they distinguish bicycles from unicycles, tricycles, and scooters. Pedal, chain, brake, and saddle are required but not delimiting (solid lines). Wheel and pedal have double solid lines indicating "multiple" (typically 2 each). Bell is optional (dashed) and light is optional and multiple (double dashed).</desc>
+  <style>
+    .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
+    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #212529; }
+    .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
+    .name { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; font-weight: 600; fill: #0c5460; }
+    .opt-name { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; font-weight: 600; fill: #856404; }
+    .backline { stroke: #212529; stroke-width: 2; fill: none; }
+    .solid { stroke: #212529; stroke-width: 1.5; fill: none; }
+    .dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
+    .delimit { stroke: #212529; stroke-width: 5; fill: none; }
+    .delimit-multi { stroke: #212529; stroke-width: 5; fill: none; }
+  </style>
+
+  <!-- Comprehensive -->
+  <rect x="420" y="20" width="120" height="42" rx="6" class="box"/>
+  <text x="480" y="40" text-anchor="middle" class="label" font-weight="600">bicycle</text>
+  <text x="480" y="55" text-anchor="middle" class="small">fictitious comprehensive</text>
+
+  <!-- Backline -->
+  <line x1="40" y1="100" x2="920" y2="100" class="backline"/>
+  <text x="20" y="104" class="small">complete</text>
+
+  <!-- ===== Delimiting parts (bold 3x) ===== -->
+  <!-- 1. frame: delimiting + required + exactly_one -->
+  <line x1="80" y1="100" x2="80" y2="210" class="delimit"/>
+  <rect x="35" y="230" width="90" height="40" rx="6" class="box"/>
+  <text x="80" y="248" text-anchor="middle" class="label">frame</text>
+  <text x="80" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- 2. wheel: delimiting + required + multiple (typically 2) -->
+  <line x1="74" y1="100" x2="74" y2="210" class="delimit-multi"/>
+  <line x1="156" y1="100" x2="156" y2="210" class="delimit-multi"/>
+  <rect x="115" y="230" width="80" height="40" rx="6" class="box"/>
+  <text x="155" y="248" text-anchor="middle" class="label">wheel</text>
+  <text x="155" y="262" text-anchor="middle" class="name">delimiting ×2</text>
+
+  <!-- 3. handlebar: delimiting + required + exactly_one -->
+  <line x1="240" y1="100" x2="240" y2="210" class="delimit"/>
+  <rect x="195" y="230" width="90" height="40" rx="6" class="box"/>
+  <text x="240" y="248" text-anchor="middle" class="label">handlebar</text>
+  <text x="240" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- ===== Required non-delimiting parts (solid) ===== -->
+  <!-- 4. pedal: required + multiple (2) -->
+  <line x1="314" y1="100" x2="314" y2="210" class="solid"/>
+  <line x1="326" y1="100" x2="326" y2="210" class="solid"/>
+  <rect x="290" y="230" width="60" height="40" rx="6" class="box"/>
+  <text x="320" y="248" text-anchor="middle" class="label">pedal</text>
+  <text x="320" y="262" text-anchor="middle" class="small">required ×2</text>
+
+  <!-- 5. chain: required + exactly_one -->
+  <line x1="400" y1="100" x2="400" y2="210" class="solid"/>
+  <rect x="365" y="230" width="70" height="40" rx="6" class="box"/>
+  <text x="400" y="248" text-anchor="middle" class="label">chain</text>
+  <text x="400" y="262" text-anchor="middle" class="small">required</text>
+
+  <!-- 6. brake: required + multiple (typically 2) -->
+  <line x1="474" y1="100" x2="474" y2="210" class="solid"/>
+  <line x1="486" y1="100" x2="486" y2="210" class="solid"/>
+  <rect x="450" y="230" width="60" height="40" rx="6" class="box"/>
+  <text x="480" y="248" text-anchor="middle" class="label">brake</text>
+  <text x="480" y="262" text-anchor="middle" class="small">required ×2</text>
+
+  <!-- 7. saddle: required + exactly_one -->
+  <line x1="560" y1="100" x2="560" y2="210" class="solid"/>
+  <rect x="520" y="230" width="80" height="40" rx="6" class="box"/>
+  <text x="560" y="248" text-anchor="middle" class="label">saddle</text>
+  <text x="560" y="262" text-anchor="middle" class="small">required</text>
+
+  <!-- ===== Optional parts (dashed) ===== -->
+  <!-- 8. bell: optional + exactly_one -->
+  <line x1="660" y1="100" x2="660" y2="210" class="dashed"/>
+  <rect x="625" y="230" width="70" height="40" rx="6" class="box"/>
+  <text x="660" y="248" text-anchor="middle" class="label">bell</text>
+  <text x="660" y="262" text-anchor="middle" class="opt-name">optional</text>
+
+  <!-- 9. light: optional + multiple (could be 0, 1, 2+) -->
+  <line x1="774" y1="100" x2="774" y2="210" class="dashed"/>
+  <line x1="786" y1="100" x2="786" y2="210" class="dashed"/>
+  <rect x="745" y="230" width="70" height="40" rx="6" class="box"/>
+  <text x="780" y="248" text-anchor="middle" class="label">light</text>
+  <text x="780" y="262" text-anchor="middle" class="opt-name">optional ×*</text>
+
+  <!-- ===== Comparison concept (out of rake, for context) ===== -->
+  <rect x="855" y="230" width="80" height="40" rx="6" fill="#f8f9fa" stroke="#adb5bd" stroke-width="1" stroke-dasharray="3 3"/>
+  <text x="895" y="248" text-anchor="middle" class="small">unicycle</text>
+  <text x="895" y="262" text-anchor="middle" class="small">(coordinate)</text>
+
+  <!-- Footer -->
+  <text x="480" y="320" text-anchor="middle" class="small">Criterion: physical structure. Delimiting parts distinguish "bicycle" from coordinate concepts:</text>
+  <text x="480" y="336" text-anchor="middle" class="small">unicycle (1 wheel), tricycle (3 wheels), scooter (no pedals, no chain), motorcycle (motor-driven).</text>
+  <text x="480" y="358" text-anchor="middle" class="small">Double lines indicate count=multiple (typically 2). Dashed lines indicate presence=optional.</text>
+  <text x="480" y="380" text-anchor="middle" class="small">Bold 3x-width = is_delimiting (behaves like a delimiting characteristic per ISO 704:2022 §5.5.4.2.1).</text>
+</svg>

--- a/public/images/hyperedge-computer-mouse.svg
+++ b/public/images/hyperedge-computer-mouse.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 540" role="img" aria-labelledby="title desc">
+  <title id="title">Generic hyperedge — computer mouse (ISO 704:2022 §5.5.4.2.1 canonical example with multidimensionality)</title>
+  <desc id="desc">A "computer mouse" genus concept at the top. Two separate rakes drop from it, each labeled with its criterion of subdivision. By means of movement detection: mechanical mouse, optomechanical mouse, optical mouse — each with a delimiting characteristic in a side rectangle. By computer connection: wired mouse, wireless mouse — each with its delimiting characteristic. Thicker backlines distinguish the two criteria of subdivision (multidimensionality per ISO 704:2022 §5.6.3).</desc>
+  <style>
+    .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
+    .genus-box { fill: #e7f1fa; stroke: #0c5460; stroke-width: 2; }
+    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #212529; }
+    .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
+    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; font-weight: 600; }
+    .char-label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 9px; fill: #6c757d; font-style: italic; }
+    .char-text { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #212529; }
+    .backline-1 { stroke: #0c5460; stroke-width: 2.5; fill: none; }
+    .backline-2 { stroke: #8b4513; stroke-width: 2.5; fill: none; }
+    .tooth-1 { stroke: #0c5460; stroke-width: 1.5; fill: none; }
+    .tooth-2 { stroke: #8b4513; stroke-width: 1.5; fill: none; }
+    .char-connector { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
+  </style>
+
+  <!-- Genus -->
+  <rect x="380" y="20" width="160" height="42" rx="6" class="genus-box"/>
+  <text x="460" y="40" text-anchor="middle" class="label" font-weight="600" fill="#0c5460">computer mouse</text>
+  <text x="460" y="55" text-anchor="middle" class="small">genus · ISO 704:2022 §5.5.4.2.1</text>
+
+  <!-- ============ Criterion 1: means of movement detection (thicker blue backline) ============ -->
+  <text x="170" y="100" text-anchor="middle" class="crit" fill="#0c5460">criterion 1: means of movement detection</text>
+  <line x1="40" y1="120" x2="320" y2="120" class="backline-1"/>
+  <line x1="40" y1="124" x2="320" y2="124" class="backline-1"/>
+
+  <!-- Drop lines -->
+  <line x1="80" y1="124" x2="80" y2="220" class="tooth-1"/>
+  <line x1="180" y1="124" x2="180" y2="220" class="tooth-1"/>
+  <line x1="280" y1="124" x2="280" y2="220" class="tooth-1"/>
+
+  <!-- Species boxes -->
+  <rect x="30" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="80" y="258" text-anchor="middle" class="label">mechanical</text>
+  <text x="80" y="272" text-anchor="middle" class="label">mouse</text>
+
+  <rect x="130" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="180" y="258" text-anchor="middle" class="label">optomechanical</text>
+  <text x="180" y="272" text-anchor="middle" class="label">mouse</text>
+
+  <rect x="230" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="280" y="258" text-anchor="middle" class="label">optical</text>
+  <text x="280" y="272" text-anchor="middle" class="label">mouse</text>
+
+  <!-- Ellipsis indicating more species not shown -->
+  <text x="335" y="262" class="small">...</text>
+
+  <!-- Characteristic side-rectangles for criterion 1 -->
+  <line x1="80" y1="280" x2="80" y2="305" class="char-connector"/>
+  <rect x="20" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd" stroke-width="1"/>
+  <text x="80" y="320" text-anchor="middle" class="char-label">delimiting characteristic</text>
+  <text x="80" y="335" text-anchor="middle" class="char-text">"detecting movement</text>
+  <text x="80" y="349" text-anchor="middle" class="char-text">by means of rollers"</text>
+
+  <line x1="180" y1="280" x2="180" y2="305" class="char-connector"/>
+  <rect x="120" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd" stroke-width="1"/>
+  <text x="180" y="320" text-anchor="middle" class="char-label">delimiting characteristic</text>
+  <text x="180" y="335" text-anchor="middle" class="char-text">"detecting movement</text>
+  <text x="180" y="349" text-anchor="middle" class="char-text">by rollers + light sensors"</text>
+
+  <line x1="280" y1="280" x2="280" y2="305" class="char-connector"/>
+  <rect x="220" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd" stroke-width="1"/>
+  <text x="280" y="320" text-anchor="middle" class="char-label">delimiting characteristic</text>
+  <text x="280" y="335" text-anchor="middle" class="char-text">"detecting movement</text>
+  <text x="280" y="349" text-anchor="middle" class="char-text">by means of light sensors"</text>
+
+  <!-- ============ Criterion 2: computer connection (thicker brown backline) ============ -->
+  <text x="690" y="100" text-anchor="middle" class="crit" fill="#8b4513">criterion 2: computer connection</text>
+  <line x1="560" y1="120" x2="880" y2="120" class="backline-2"/>
+  <line x1="560" y1="124" x2="880" y2="124" class="backline-2"/>
+
+  <!-- Drop lines -->
+  <line x1="630" y1="124" x2="630" y2="220" class="tooth-2"/>
+  <line x1="810" y1="124" x2="810" y2="220" class="tooth-2"/>
+
+  <!-- Species boxes -->
+  <rect x="580" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="630" y="258" text-anchor="middle" class="label">wired</text>
+  <text x="630" y="272" text-anchor="middle" class="label">mouse</text>
+
+  <rect x="760" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="810" y="258" text-anchor="middle" class="label">wireless</text>
+  <text x="810" y="272" text-anchor="middle" class="label">mouse</text>
+
+  <text x="893" y="262" class="small">...</text>
+
+  <!-- Characteristic side-rectangles for criterion 2 -->
+  <line x1="630" y1="280" x2="630" y2="305" class="char-connector"/>
+  <rect x="570" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd" stroke-width="1"/>
+  <text x="630" y="320" text-anchor="middle" class="char-label">delimiting characteristic</text>
+  <text x="630" y="335" text-anchor="middle" class="char-text">"using a corded</text>
+  <text x="630" y="349" text-anchor="middle" class="char-text">electrical connection"</text>
+
+  <line x1="810" y1="280" x2="810" y2="305" class="char-connector"/>
+  <rect x="750" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd" stroke-width="1"/>
+  <text x="810" y="320" text-anchor="middle" class="char-label">delimiting characteristic</text>
+  <text x="810" y="335" text-anchor="middle" class="char-text">"using a cordless</text>
+  <text x="810" y="349" text-anchor="middle" class="char-text">light or sound connection"</text>
+
+  <!-- ============ Separator between criteria ============ -->
+  <line x1="460" y1="85" x2="460" y2="380" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
+
+  <!-- ============ Footnotes ============ -->
+  <text x="460" y="400" text-anchor="middle" class="small">Multidimensionality (ISO 704:2022 §5.6.3): one genus, multiple criteria of subdivision → multiple rakes.</text>
+  <text x="460" y="416" text-anchor="middle" class="small">Each species carries a delimiting characteristic that distinguishes it from coordinate concepts.</text>
+  <text x="460" y="432" text-anchor="middle" class="small">Thicker backlines distinguish the two criteria. Species within one rake are coordinate; across rakes they are not.</text>
+
+  <!-- Wire-format preview -->
+  <rect x="40" y="450" width="840" height="80" rx="4" fill="#f8f9fa" stroke="#dee2e6"/>
+  <text x="55" y="468" class="small" font-family="ui-monospace, monospace" fill="#0c5460"># relations/example-computer-mouse/by-means-of-movement-detection.yaml</text>
+  <text x="55" y="482" class="small" font-family="ui-monospace, monospace">$id: example-computer-mouse/by-means-of-movement-detection</text>
+  <text x="55" y="496" class="small" font-family="ui-monospace, monospace">type: generic_relation</text>
+  <text x="55" y="510" class="small" font-family="ui-monospace, monospace">comprehensive: { source: EXAMPLE, id: "computer-mouse" }</text>
+  <text x="55" y="524" class="small" font-family="ui-monospace, monospace">criterion: { eng: means of movement detection }</text>
+
+  <text x="455" y="468" class="small" font-family="ui-monospace, monospace">members:</text>
+  <text x="455" y="482" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "mechanical-mouse" }</text>
+  <text x="455" y="496" class="small" font-family="ui-monospace, monospace">    characteristic: { eng: detecting movement by rollers }</text>
+  <text x="455" y="510" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "optomechanical-mouse" }</text>
+  <text x="455" y="524" class="small" font-family="ui-monospace, monospace">    characteristic: { eng: ... by rollers + light sensors }</text>
+</svg>

--- a/public/images/hyperedge-generalization.svg
+++ b/public/images/hyperedge-generalization.svg
@@ -1,68 +1,114 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 460" role="img" aria-labelledby="title desc">
-  <title id="title">Generalization hyperedge — measurement standard with two distinct decompositions</title>
-  <desc id="desc">A comprehensive concept "measurement standard" at the top. Two separate rakes drop from it, each labeled with its criterion of subdivision: "by realization medium" with three species (reference material, measuring system, material measure), and "by governance level" with two species (international, national). The two rakes share the same comprehensive but are distinct decompositions distinguished by criterion.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 580" role="img" aria-labelledby="title desc">
+  <title id="title">Generalization hyperedge — OIML measurement standard with two criteria and delimiting characteristics</title>
+  <desc id="desc">OIML V 2-200:2010 measurement standard (5.1) genus at the top. Two criterion groups drop from it. By realization medium: reference material (characteristic: "material, certified for property"), measuring system (characteristic: "assembly of measuring instruments"), material measure (characteristic: "device that reproduces a quantity"). By governance level: international (characteristic: "recognized by international agreement"), national (characteristic: "recognized by national authority"). Each species carries its delimiting characteristic in a side rectangle per ISO 704:2022 §5.5.4.2.1 convention.</desc>
   <style>
     .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
-    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; fill: #212529; }
+    .genus-box { fill: #e7f1fa; stroke: #0c5460; stroke-width: 2; }
+    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #212529; }
     .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
-    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; }
-    .backline { stroke: #212529; stroke-width: 2; fill: none; }
-    .tooth-solid { stroke: #212529; stroke-width: 1.5; fill: none; }
+    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; font-weight: 600; }
+    .char-label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 9px; fill: #6c757d; font-style: italic; }
+    .char-text { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #212529; }
+    .backline-1 { stroke: #0c5460; stroke-width: 2.5; fill: none; }
+    .backline-2 { stroke: #8b4513; stroke-width: 2.5; fill: none; }
+    .tooth-1 { stroke: #0c5460; stroke-width: 1.5; fill: none; }
+    .tooth-2 { stroke: #8b4513; stroke-width: 1.5; fill: none; }
+    .char-connector { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
   </style>
 
-  <!-- Genus concept (shared comprehensive) -->
-  <rect x="290" y="20" width="180" height="42" rx="6" class="box"/>
-  <text x="380" y="40" text-anchor="middle" class="label" font-weight="600">measurement standard</text>
-  <text x="380" y="55" text-anchor="middle" class="small">genus · VIML 5.1</text>
+  <!-- Genus -->
+  <rect x="290" y="20" width="200" height="42" rx="6" class="genus-box"/>
+  <text x="390" y="40" text-anchor="middle" class="label" font-weight="600" fill="#0c5460">measurement standard</text>
+  <text x="390" y="55" text-anchor="middle" class="small">genus · VIML 5.1</text>
 
-  <!-- ============ Criterion group 1: by realization medium ============ -->
-  <text x="120" y="100" class="crit" font-weight="600">criterion: by realization medium</text>
+  <!-- ============ Criterion 1: by realization medium ============ -->
+  <text x="140" y="100" text-anchor="middle" class="crit" fill="#0c5460">criterion 1: by realization medium</text>
+  <line x1="30" y1="120" x2="280" y2="120" class="backline-1"/>
+  <line x1="30" y1="124" x2="280" y2="124" class="backline-1"/>
 
-  <!-- Backline for group 1 -->
-  <line x1="60" y1="120" x2="240" y2="120" class="backline"/>
+  <line x1="70" y1="124" x2="70" y2="220" class="tooth-1"/>
+  <line x1="155" y1="124" x2="155" y2="220" class="tooth-1"/>
+  <line x1="240" y1="124" x2="240" y2="220" class="tooth-1"/>
 
-  <!-- Drop lines (3 solid teeth = compulsory, exactly_one each) -->
-  <line x1="80" y1="120" x2="80" y2="200" class="tooth-solid"/>
-  <line x1="150" y1="120" x2="150" y2="200" class="tooth-solid"/>
-  <line x1="220" y1="120" x2="220" y2="200" class="tooth-solid"/>
+  <rect x="20" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="70" y="258" text-anchor="middle" class="label">reference</text>
+  <text x="70" y="272" text-anchor="middle" class="label">material</text>
 
-  <!-- Species boxes -->
-  <rect x="30" y="220" width="100" height="40" rx="6" class="box"/>
-  <text x="80" y="238" text-anchor="middle" class="label">reference</text>
-  <text x="80" y="252" text-anchor="middle" class="label">material</text>
+  <rect x="105" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="155" y="258" text-anchor="middle" class="label">measuring</text>
+  <text x="155" y="272" text-anchor="middle" class="label">system</text>
 
-  <rect x="105" y="220" width="90" height="40" rx="6" class="box"/>
-  <text x="150" y="238" text-anchor="middle" class="label">measuring</text>
-  <text x="150" y="252" text-anchor="middle" class="label">system</text>
+  <rect x="190" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="240" y="258" text-anchor="middle" class="label">material</text>
+  <text x="240" y="272" text-anchor="middle" class="label">measure</text>
 
-  <rect x="180" y="220" width="80" height="40" rx="6" class="box"/>
-  <text x="220" y="238" text-anchor="middle" class="label">material</text>
-  <text x="220" y="252" text-anchor="middle" class="label">measure</text>
+  <!-- Characteristics for criterion 1 -->
+  <line x1="70" y1="280" x2="70" y2="305" class="char-connector"/>
+  <rect x="10" y="305" width="120" height="60" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="70" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="70" y="335" text-anchor="middle" class="char-text">"material, sufficiently</text>
+  <text x="70" y="349" text-anchor="middle" class="char-text">homogeneous and stable</text>
+  <text x="70" y="363" text-anchor="middle" class="char-text">for certified property"</text>
 
-  <!-- ============ Criterion group 2: by governance level ============ -->
-  <text x="490" y="100" class="crit" font-weight="600">criterion: by governance level</text>
+  <line x1="155" y1="280" x2="155" y2="305" class="char-connector"/>
+  <rect x="95" y="305" width="120" height="60" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="155" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="155" y="335" text-anchor="middle" class="char-text">"assembly of measuring</text>
+  <text x="155" y="349" text-anchor="middle" class="char-text">instruments + auxiliary</text>
+  <text x="155" y="363" text-anchor="middle" class="char-text">apparatus"</text>
 
-  <!-- Backline for group 2 -->
-  <line x1="440" y1="120" x2="700" y2="120" class="backline"/>
+  <line x1="240" y1="280" x2="240" y2="305" class="char-connector"/>
+  <rect x="180" y="305" width="120" height="60" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="240" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="240" y="335" text-anchor="middle" class="char-text">"device that reproduces</text>
+  <text x="240" y="349" text-anchor="middle" class="char-text">a given quantity value</text>
+  <text x="240" y="363" text-anchor="middle" class="char-text">during use"</text>
 
-  <!-- Drop lines (2 solid teeth) -->
-  <line x1="500" y1="120" x2="500" y2="200" class="tooth-solid"/>
-  <line x1="640" y1="120" x2="640" y2="200" class="tooth-solid"/>
+  <!-- ============ Criterion 2: by governance level ============ -->
+  <text x="600" y="100" text-anchor="middle" class="crit" fill="#8b4513">criterion 2: by governance level</text>
+  <line x1="490" y1="120" x2="760" y2="120" class="backline-2"/>
+  <line x1="490" y1="124" x2="760" y2="124" class="backline-2"/>
 
-  <!-- Species boxes -->
-  <rect x="440" y="220" width="120" height="40" rx="6" class="box"/>
-  <text x="500" y="238" text-anchor="middle" class="label">international</text>
-  <text x="500" y="252" text-anchor="middle" class="label">standard</text>
+  <line x1="550" y1="124" x2="550" y2="220" class="tooth-2"/>
+  <line x1="700" y1="124" x2="700" y2="220" class="tooth-2"/>
 
-  <rect x="580" y="220" width="120" height="40" rx="6" class="box"/>
-  <text x="640" y="238" text-anchor="middle" class="label">national</text>
-  <text x="640" y="252" text-anchor="middle" class="label">standard</text>
+  <rect x="490" y="240" width="120" height="40" rx="6" class="box"/>
+  <text x="550" y="258" text-anchor="middle" class="label">international</text>
+  <text x="550" y="272" text-anchor="middle" class="label">standard</text>
 
-  <!-- ============ Separator ============ -->
-  <line x1="380" y1="85" x2="380" y2="280" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
+  <rect x="640" y="240" width="120" height="40" rx="6" class="box"/>
+  <text x="700" y="258" text-anchor="middle" class="label">national</text>
+  <text x="700" y="272" text-anchor="middle" class="label">standard</text>
 
-  <!-- Footer legend -->
-  <text x="380" y="380" text-anchor="middle" class="small">ISO 704:2022 §5.5.4.1 — same genus, two distinct decompositions</text>
-  <text x="380" y="396" text-anchor="middle" class="small">Species within one rake are coordinate concepts (share genus + share criterion)</text>
-  <text x="380" y="418" text-anchor="middle" class="small">OIML V 2-200:2010 has 6 such groups on this single comprehensive</text>
+  <!-- Characteristics for criterion 2 -->
+  <line x1="550" y1="280" x2="550" y2="305" class="char-connector"/>
+  <rect x="490" y="305" width="120" height="60" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="550" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="550" y="335" text-anchor="middle" class="char-text">"recognized by signatory</text>
+  <text x="550" y="349" text-anchor="middle" class="char-text">states of an international</text>
+  <text x="550" y="363" text-anchor="middle" class="char-text">agreement (OIML)"</text>
+
+  <line x1="700" y1="280" x2="700" y2="305" class="char-connector"/>
+  <rect x="640" y="305" width="120" height="60" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="700" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="700" y="335" text-anchor="middle" class="char-text">"recognized by national</text>
+  <text x="700" y="349" text-anchor="middle" class="char-text">metrology authority</text>
+  <text x="700" y="363" text-anchor="middle" class="char-text">(NMI)"</text>
+
+  <!-- Separator -->
+  <line x1="385" y1="85" x2="385" y2="395" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
+
+  <!-- Footer -->
+  <text x="390" y="415" text-anchor="middle" class="small">Multidimensionality (ISO 704:2022 §5.6.3): OIML 5.1 has 6 such criteria in the full diagram.</text>
+  <text x="390" y="431" text-anchor="middle" class="small">Each species carries its delimiting characteristic per §5.5.4.2.1.</text>
+
+  <!-- Wire preview -->
+  <rect x="40" y="450" width="700" height="115" rx="4" fill="#f8f9fa" stroke="#dee2e6"/>
+  <text x="55" y="468" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/viml-5-1/by-realization-medium.yaml</text>
+  <text x="55" y="484" class="small" font-family="ui-monospace, monospace">type: generic_relation</text>
+  <text x="55" y="498" class="small" font-family="ui-monospace, monospace">comprehensive: { source: VIML, id: "5.1" }</text>
+  <text x="55" y="512" class="small" font-family="ui-monospace, monospace">criterion: { eng: by realization medium }</text>
+  <text x="55" y="526" class="small" font-family="ui-monospace, monospace">members:</text>
+  <text x="55" y="540" class="small" font-family="ui-monospace, monospace">  - ref: { source: VIML, id: "5.13" }</text>
+  <text x="55" y="554" class="small" font-family="ui-monospace, monospace">    characteristic: { eng: material sufficiently homogeneous ... }</text>
 </svg>

--- a/public/images/hyperedge-optomechanical-mouse.svg
+++ b/public/images/hyperedge-optomechanical-mouse.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 380" role="img" aria-labelledby="title desc">
+  <title id="title">Partitive hyperedge — optomechanical mouse (ISO 704:2022 §5.5.4.2.2 canonical example)</title>
+  <desc id="desc">The optomechanical mouse comprehensive concept at the top. Eight parts drop from a shared horizontal backline. Five parts are drawn with bold 3x-width lines (delimiting — mouse ball, x-axis roller, y-axis roller, infrared emitter, infrared sensor); two parts with normal solid lines (circuit board, mouse button — required but not delimiting); one part with a dashed line (mouse wheel — optional, not all optomechanical mice have one).</desc>
+  <style>
+    .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
+    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #212529; }
+    .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
+    .name { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; font-weight: 600; fill: #0c5460; }
+    .backline { stroke: #212529; stroke-width: 2; fill: none; }
+    .tooth-solid { stroke: #212529; stroke-width: 1.5; fill: none; }
+    .tooth-dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
+    .tooth-delimit { stroke: #212529; stroke-width: 5; fill: none; }
+  </style>
+
+  <!-- Comprehensive concept -->
+  <rect x="380" y="20" width="200" height="42" rx="6" class="box"/>
+  <text x="480" y="40" text-anchor="middle" class="label" font-weight="600">optomechanical mouse</text>
+  <text x="480" y="55" text-anchor="middle" class="small">comprehensive · ISO 704:2022 §5.5.4.2.2</text>
+
+  <!-- Backline (complete) -->
+  <line x1="60" y1="100" x2="900" y2="100" class="backline"/>
+  <text x="30" y="104" class="small">complete</text>
+
+  <!-- ===== 5 delimiting parts (bold 3x) ===== -->
+  <!-- 1. mouse ball -->
+  <line x1="90" y1="100" x2="90" y2="210" class="tooth-delimit"/>
+  <rect x="40" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="90" y="248" text-anchor="middle" class="label">mouse ball</text>
+  <text x="90" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- 2. x-axis roller -->
+  <line x1="190" y1="100" x2="190" y2="210" class="tooth-delimit"/>
+  <rect x="140" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="190" y="248" text-anchor="middle" class="label">x-axis roller</text>
+  <text x="190" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- 3. y-axis roller -->
+  <line x1="290" y1="100" x2="290" y2="210" class="tooth-delimit"/>
+  <rect x="240" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="290" y="248" text-anchor="middle" class="label">y-axis roller</text>
+  <text x="290" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- 4. infrared emitter -->
+  <line x1="390" y1="100" x2="390" y2="210" class="tooth-delimit"/>
+  <rect x="340" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="390" y="248" text-anchor="middle" class="label">infrared emitter</text>
+  <text x="390" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- 5. infrared sensor -->
+  <line x1="490" y1="100" x2="490" y2="210" class="tooth-delimit"/>
+  <rect x="440" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="490" y="248" text-anchor="middle" class="label">infrared sensor</text>
+  <text x="490" y="262" text-anchor="middle" class="name">delimiting</text>
+
+  <!-- ===== 2 non-delimiting required parts (solid) ===== -->
+  <!-- 6. circuit board -->
+  <line x1="600" y1="100" x2="600" y2="210" class="tooth-solid"/>
+  <rect x="550" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="600" y="248" text-anchor="middle" class="label">circuit board</text>
+  <text x="600" y="262" text-anchor="middle" class="small">required</text>
+
+  <!-- 7. mouse button -->
+  <line x1="710" y1="100" x2="710" y2="210" class="tooth-solid"/>
+  <rect x="660" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="710" y="248" text-anchor="middle" class="label">mouse button</text>
+  <text x="710" y="262" text-anchor="middle" class="small">required</text>
+
+  <!-- ===== 1 optional part (dashed) ===== -->
+  <!-- 8. mouse wheel -->
+  <line x1="820" y1="100" x2="820" y2="210" class="tooth-dashed"/>
+  <rect x="770" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="820" y="248" text-anchor="middle" class="label">mouse wheel</text>
+  <text x="820" y="262" text-anchor="middle" class="small">optional</text>
+
+  <!-- Footer legend -->
+  <text x="480" y="320" text-anchor="middle" class="small">The 5 delimiting parts distinguish "optomechanical mouse" from coordinate concepts:</text>
+  <text x="480" y="336" text-anchor="middle" class="small">"mechanical mouse" (no infrared emitter/sensor) and "optical mouse" (no ball, no rollers).</text>
+  <text x="480" y="358" text-anchor="middle" class="small">Mouse button and wheel are not delimiting — all computer mice have buttons; wheels are optional.</text>
+</svg>

--- a/public/images/hyperedge-vehicle.svg
+++ b/public/images/hyperedge-vehicle.svg
@@ -1,105 +1,150 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 540" role="img" aria-labelledby="title desc">
-  <title id="title">Generic hyperedge — fictitious example: vehicle by motive power and by terrain</title>
-  <desc id="desc">A "vehicle" genus concept at the top. Two separate rakes drop from it, each labeled with its criterion of subdivision. By motive power: human-powered, animal-powered, motor-powered, wind-powered. By terrain: land, water, air, space. The two rakes share the same genus but are distinct decompositions distinguished by criterion. Species within one rake are coordinate; species across rakes are not.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" role="img" aria-labelledby="title desc">
+  <title id="title">Generic hyperedge — fictitious vehicle with delimiting characteristics on each species</title>
+  <desc id="desc">A "vehicle" genus at the top. Two rakes drop from it, each with its criterion of subdivision and each species carrying a delimiting characteristic in a side rectangle. By motive power: human-powered (characteristic: "propelled by human force"), animal-powered, motor-powered, wind-powered. By terrain: land, water, air, space.</desc>
   <style>
     .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
+    .genus-box { fill: #e7f1fa; stroke: #0c5460; stroke-width: 2; }
     .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #212529; }
     .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
-    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; }
-    .backline { stroke: #212529; stroke-width: 2; fill: none; }
-    .solid { stroke: #212529; stroke-width: 1.5; fill: none; }
+    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; font-weight: 600; }
+    .char-label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 9px; fill: #6c757d; font-style: italic; }
+    .char-text { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #212529; }
+    .backline-1 { stroke: #0c5460; stroke-width: 2.5; fill: none; }
+    .backline-2 { stroke: #8b4513; stroke-width: 2.5; fill: none; }
+    .tooth-1 { stroke: #0c5460; stroke-width: 1.5; fill: none; }
+    .tooth-2 { stroke: #8b4513; stroke-width: 1.5; fill: none; }
+    .char-connector { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
   </style>
 
   <!-- Genus -->
-  <rect x="390" y="20" width="100" height="42" rx="6" class="box"/>
-  <text x="440" y="40" text-anchor="middle" class="label" font-weight="600">vehicle</text>
-  <text x="440" y="55" text-anchor="middle" class="small">fictitious genus</text>
+  <rect x="410" y="20" width="140" height="42" rx="6" class="genus-box"/>
+  <text x="480" y="40" text-anchor="middle" class="label" font-weight="600" fill="#0c5460">vehicle</text>
+  <text x="480" y="55" text-anchor="middle" class="small">fictitious genus</text>
 
   <!-- ============ Criterion 1: by motive power ============ -->
-  <text x="200" y="100" text-anchor="middle" class="crit" font-weight="600">criterion: by motive power</text>
+  <text x="200" y="100" text-anchor="middle" class="crit" fill="#0c5460">criterion 1: by motive power</text>
+  <line x1="40" y1="120" x2="380" y2="120" class="backline-1"/>
+  <line x1="40" y1="124" x2="380" y2="124" class="backline-1"/>
 
-  <!-- Backline -->
-  <line x1="60" y1="120" x2="380" y2="120" class="backline"/>
+  <line x1="80" y1="124" x2="80" y2="220" class="tooth-1"/>
+  <line x1="180" y1="124" x2="180" y2="220" class="tooth-1"/>
+  <line x1="280" y1="124" x2="280" y2="220" class="tooth-1"/>
+  <line x1="360" y1="124" x2="360" y2="220" class="tooth-1"/>
 
-  <!-- Drop lines: 4 solid teeth -->
-  <line x1="100" y1="120" x2="100" y2="210" class="solid"/>
-  <line x1="200" y1="120" x2="200" y2="210" class="solid"/>
-  <line x1="300" y1="120" x2="300" y2="210" class="solid"/>
-  <line x1="360" y1="120" x2="360" y2="210" class="solid"/>
+  <rect x="30" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="80" y="258" text-anchor="middle" class="label">human-powered</text>
+  <text x="80" y="272" text-anchor="middle" class="small">bicycle, scooter</text>
 
-  <!-- Species boxes -->
-  <rect x="50" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="100" y="248" text-anchor="middle" class="label">human-powered</text>
-  <text x="100" y="262" text-anchor="middle" class="small">bicycle, scooter</text>
+  <rect x="130" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="180" y="258" text-anchor="middle" class="label">animal-powered</text>
+  <text x="180" y="272" text-anchor="middle" class="small">horse cart</text>
 
-  <rect x="150" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="200" y="248" text-anchor="middle" class="label">animal-powered</text>
-  <text x="200" y="262" text-anchor="middle" class="small">horse cart, ox cart</text>
+  <rect x="230" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="280" y="258" text-anchor="middle" class="label">motor-powered</text>
+  <text x="280" y="272" text-anchor="middle" class="small">car, truck, train</text>
 
-  <rect x="250" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="300" y="248" text-anchor="middle" class="label">motor-powered</text>
-  <text x="300" y="262" text-anchor="middle" class="small">car, truck, train</text>
+  <rect x="310" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="360" y="258" text-anchor="middle" class="label">wind-powered</text>
+  <text x="360" y="272" text-anchor="middle" class="small">sailboat</text>
 
-  <rect x="330" y="230" width="80" height="40" rx="6" class="box"/>
-  <text x="370" y="248" text-anchor="middle" class="label">wind-powered</text>
-  <text x="370" y="262" text-anchor="middle" class="small">sailboat</text>
+  <!-- Characteristics for criterion 1 -->
+  <line x1="80" y1="280" x2="80" y2="305" class="char-connector"/>
+  <rect x="20" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="80" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="80" y="335" text-anchor="middle" class="char-text">"propelled by</text>
+  <text x="80" y="349" text-anchor="middle" class="char-text">human force"</text>
 
-  <!-- (duplicate tooth fix removed above) -->
+  <line x1="180" y1="280" x2="180" y2="305" class="char-connector"/>
+  <rect x="120" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="180" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="180" y="335" text-anchor="middle" class="char-text">"pulled by</text>
+  <text x="180" y="349" text-anchor="middle" class="char-text">draft animal"</text>
+
+  <line x1="280" y1="280" x2="280" y2="305" class="char-connector"/>
+  <rect x="220" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="280" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="280" y="335" text-anchor="middle" class="char-text">"powered by</text>
+  <text x="280" y="349" text-anchor="middle" class="char-text">an engine"</text>
+
+  <line x1="360" y1="280" x2="360" y2="305" class="char-connector"/>
+  <rect x="300" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="360" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="360" y="335" text-anchor="middle" class="char-text">"propelled by</text>
+  <text x="360" y="349" text-anchor="middle" class="char-text">wind on sails"</text>
 
   <!-- ============ Criterion 2: by terrain ============ -->
-  <text x="680" y="100" text-anchor="middle" class="crit" font-weight="600">criterion: by terrain</text>
+  <text x="700" y="100" text-anchor="middle" class="crit" fill="#8b4513">criterion 2: by terrain</text>
+  <line x1="540" y1="120" x2="900" y2="120" class="backline-2"/>
+  <line x1="540" y1="124" x2="900" y2="124" class="backline-2"/>
 
-  <!-- Backline -->
-  <line x1="520" y1="120" x2="840" y2="120" class="backline"/>
+  <line x1="580" y1="124" x2="580" y2="220" class="tooth-2"/>
+  <line x1="680" y1="124" x2="680" y2="220" class="tooth-2"/>
+  <line x1="780" y1="124" x2="780" y2="220" class="tooth-2"/>
+  <line x1="870" y1="124" x2="870" y2="220" class="tooth-2"/>
 
-  <!-- 4 solid teeth -->
-  <line x1="560" y1="120" x2="560" y2="210" class="solid"/>
-  <line x1="650" y1="120" x2="650" y2="210" class="solid"/>
-  <line x1="740" y1="120" x2="740" y2="210" class="solid"/>
-  <line x1="820" y1="120" x2="820" y2="210" class="solid"/>
+  <rect x="530" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="580" y="258" text-anchor="middle" class="label">land vehicle</text>
+  <text x="580" y="272" text-anchor="middle" class="small">car, bike, train</text>
 
-  <!-- Species boxes -->
-  <rect x="510" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="560" y="248" text-anchor="middle" class="label">land vehicle</text>
-  <text x="560" y="262" text-anchor="middle" class="small">car, bike, train</text>
+  <rect x="630" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="680" y="258" text-anchor="middle" class="label">water vehicle</text>
+  <text x="680" y="272" text-anchor="middle" class="small">boat, submarine</text>
 
-  <rect x="600" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="650" y="248" text-anchor="middle" class="label">water vehicle</text>
-  <text x="650" y="262" text-anchor="middle" class="small">boat, submarine</text>
+  <rect x="730" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="780" y="258" text-anchor="middle" class="label">air vehicle</text>
+  <text x="780" y="272" text-anchor="middle" class="small">plane, balloon</text>
 
-  <rect x="690" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="740" y="248" text-anchor="middle" class="label">air vehicle</text>
-  <text x="740" y="262" text-anchor="middle" class="small">plane, balloon</text>
+  <rect x="820" y="240" width="100" height="40" rx="6" class="box"/>
+  <text x="870" y="258" text-anchor="middle" class="label">space vehicle</text>
+  <text x="870" y="272" text-anchor="middle" class="small">rocket, probe</text>
 
-  <rect x="770" y="230" width="100" height="40" rx="6" class="box"/>
-  <text x="820" y="248" text-anchor="middle" class="label">space vehicle</text>
-  <text x="820" y="262" text-anchor="middle" class="small">rocket, probe</text>
+  <!-- Characteristics for criterion 2 -->
+  <line x1="580" y1="280" x2="580" y2="305" class="char-connector"/>
+  <rect x="520" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="580" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="580" y="335" text-anchor="middle" class="char-text">"travels on</text>
+  <text x="580" y="349" text-anchor="middle" class="char-text">solid ground"</text>
 
-  <!-- ============ Separator ============ -->
-  <line x1="450" y1="85" x2="450" y2="290" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
+  <line x1="680" y1="280" x2="680" y2="305" class="char-connector"/>
+  <rect x="620" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="680" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="680" y="335" text-anchor="middle" class="char-text">"travels on</text>
+  <text x="680" y="349" text-anchor="middle" class="char-text">or under water"</text>
 
-  <!-- ============ Footnotes ============ -->
-  <text x="440" y="320" text-anchor="middle" class="small">Two GenericHyperedges on the same genus, distinguished by criterion. Each is a distinct decomposition.</text>
+  <line x1="780" y1="280" x2="780" y2="305" class="char-connector"/>
+  <rect x="720" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="780" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="780" y="335" text-anchor="middle" class="char-text">"travels through</text>
+  <text x="780" y="349" text-anchor="middle" class="char-text">the atmosphere"</text>
 
-  <text x="440" y="345" text-anchor="middle" class="small">Within one rake, species are coordinate concepts (share genus + share criterion).</text>
-  <text x="440" y="361" text-anchor="middle" class="small">"bicycle" (human-powered) and "car" (motor-powered) are coordinate; "bicycle" and "boat" are NOT.</text>
+  <line x1="870" y1="280" x2="870" y2="305" class="char-connector"/>
+  <rect x="810" y="305" width="120" height="50" rx="3" fill="#fff" stroke="#adb5bd"/>
+  <text x="870" y="320" text-anchor="middle" class="char-label">characteristic</text>
+  <text x="870" y="335" text-anchor="middle" class="char-text">"travels beyond</text>
+  <text x="870" y="349" text-anchor="middle" class="char-text">Earth's atmosphere"</text>
 
-  <!-- Wire-format preview -->
-  <rect x="40" y="390" width="800" height="135" rx="4" fill="#f8f9fa" stroke="#dee2e6"/>
-  <text x="55" y="412" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/example-vehicle/by-motive-power.yaml</text>
-  <text x="55" y="428" class="small" font-family="ui-monospace, monospace">$id: example-vehicle/by-motive-power</text>
-  <text x="55" y="444" class="small" font-family="ui-monospace, monospace">type: generic_relation</text>
-  <text x="55" y="460" class="small" font-family="ui-monospace, monospace">comprehensive: { source: EXAMPLE, id: "vehicle" }</text>
-  <text x="55" y="476" class="small" font-family="ui-monospace, monospace">members:</text>
-  <text x="55" y="492" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "human-powered-vehicle" }</text>
-  <text x="55" y="508" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "animal-powered-vehicle" }</text>
-  <text x="55" y="524" class="small" font-family="ui-monospace, monospace">  - ... (motor-powered, wind-powered)</text>
+  <!-- Separator -->
+  <line x1="470" y1="85" x2="470" y2="380" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
 
-  <text x="455" y="428" class="small" font-family="ui-monospace, monospace">completeness: complete</text>
-  <text x="455" y="444" class="small" font-family="ui-monospace, monospace">criterion:</text>
-  <text x="455" y="460" class="small" font-family="ui-monospace, monospace">  eng: by motive power</text>
-  <text x="455" y="476" class="small" font-family="ui-monospace, monospace">  fra: par force motrice</text>
+  <!-- Footer -->
+  <text x="480" y="395" text-anchor="middle" class="small">Multidimensionality (ISO 704:2022 §5.6.3): same genus, different criteria → distinct hyperedges.</text>
+  <text x="480" y="411" text-anchor="middle" class="small">Each species carries its delimiting characteristic — the intension-difference that makes it coordinate with its siblings.</text>
+  <text x="480" y="427" text-anchor="middle" class="small">Thicker backlines (blue / brown) distinguish the two criteria of subdivision.</text>
 
-  <text x="455" y="500" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/example-vehicle/by-terrain.yaml — second hyperedge</text>
-  <text x="455" y="516" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># same comprehensive, different criterion → distinct</text>
+  <!-- Wire preview -->
+  <rect x="40" y="450" width="880" height="115" rx="4" fill="#f8f9fa" stroke="#dee2e6"/>
+  <text x="55" y="468" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/example-vehicle/by-motive-power.yaml</text>
+  <text x="55" y="484" class="small" font-family="ui-monospace, monospace">type: generic_relation</text>
+  <text x="55" y="498" class="small" font-family="ui-monospace, monospace">comprehensive: { source: EXAMPLE, id: "vehicle" }</text>
+  <text x="55" y="512" class="small" font-family="ui-monospace, monospace">criterion: { eng: by motive power }</text>
+  <text x="55" y="526" class="small" font-family="ui-monospace, monospace">members:</text>
+  <text x="55" y="540" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "human-powered-vehicle" }</text>
+  <text x="55" y="554" class="small" font-family="ui-monospace, monospace">    characteristic: { eng: propelled by human force }</text>
+
+  <text x="500" y="484" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/example-vehicle/by-terrain.yaml — distinct hyperedge</text>
+  <text x="500" y="500" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># same comprehensive, different criterion</text>
+  <text x="500" y="516" class="small" font-family="ui-monospace, monospace" fill="#6c757d">type: generic_relation</text>
+  <text x="500" y="532" class="small" font-family="ui-monospace, monospace" fill="#6c757d">comprehensive: { source: EXAMPLE, id: "vehicle" }</text>
+  <text x="500" y="548" class="small" font-family="ui-monospace, monospace" fill="#6c757d">criterion: { eng: by terrain }</text>
+  <text x="500" y="564" class="small" font-family="ui-monospace, monospace" fill="#6c757d">members: [ ... land / water / air / space ... ]</text>
 </svg>

--- a/public/images/hyperedge-vehicle.svg
+++ b/public/images/hyperedge-vehicle.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 540" role="img" aria-labelledby="title desc">
+  <title id="title">Generic hyperedge — fictitious example: vehicle by motive power and by terrain</title>
+  <desc id="desc">A "vehicle" genus concept at the top. Two separate rakes drop from it, each labeled with its criterion of subdivision. By motive power: human-powered, animal-powered, motor-powered, wind-powered. By terrain: land, water, air, space. The two rakes share the same genus but are distinct decompositions distinguished by criterion. Species within one rake are coordinate; species across rakes are not.</desc>
+  <style>
+    .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
+    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 12px; fill: #212529; }
+    .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
+    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; }
+    .backline { stroke: #212529; stroke-width: 2; fill: none; }
+    .solid { stroke: #212529; stroke-width: 1.5; fill: none; }
+  </style>
+
+  <!-- Genus -->
+  <rect x="390" y="20" width="100" height="42" rx="6" class="box"/>
+  <text x="440" y="40" text-anchor="middle" class="label" font-weight="600">vehicle</text>
+  <text x="440" y="55" text-anchor="middle" class="small">fictitious genus</text>
+
+  <!-- ============ Criterion 1: by motive power ============ -->
+  <text x="200" y="100" text-anchor="middle" class="crit" font-weight="600">criterion: by motive power</text>
+
+  <!-- Backline -->
+  <line x1="60" y1="120" x2="380" y2="120" class="backline"/>
+
+  <!-- Drop lines: 4 solid teeth -->
+  <line x1="100" y1="120" x2="100" y2="210" class="solid"/>
+  <line x1="200" y1="120" x2="200" y2="210" class="solid"/>
+  <line x1="300" y1="120" x2="300" y2="210" class="solid"/>
+  <line x1="360" y1="120" x2="360" y2="210" class="solid"/>
+
+  <!-- Species boxes -->
+  <rect x="50" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="100" y="248" text-anchor="middle" class="label">human-powered</text>
+  <text x="100" y="262" text-anchor="middle" class="small">bicycle, scooter</text>
+
+  <rect x="150" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="200" y="248" text-anchor="middle" class="label">animal-powered</text>
+  <text x="200" y="262" text-anchor="middle" class="small">horse cart, ox cart</text>
+
+  <rect x="250" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="300" y="248" text-anchor="middle" class="label">motor-powered</text>
+  <text x="300" y="262" text-anchor="middle" class="small">car, truck, train</text>
+
+  <rect x="330" y="230" width="80" height="40" rx="6" class="box"/>
+  <text x="370" y="248" text-anchor="middle" class="label">wind-powered</text>
+  <text x="370" y="262" text-anchor="middle" class="small">sailboat</text>
+
+  <!-- (duplicate tooth fix removed above) -->
+
+  <!-- ============ Criterion 2: by terrain ============ -->
+  <text x="680" y="100" text-anchor="middle" class="crit" font-weight="600">criterion: by terrain</text>
+
+  <!-- Backline -->
+  <line x1="520" y1="120" x2="840" y2="120" class="backline"/>
+
+  <!-- 4 solid teeth -->
+  <line x1="560" y1="120" x2="560" y2="210" class="solid"/>
+  <line x1="650" y1="120" x2="650" y2="210" class="solid"/>
+  <line x1="740" y1="120" x2="740" y2="210" class="solid"/>
+  <line x1="820" y1="120" x2="820" y2="210" class="solid"/>
+
+  <!-- Species boxes -->
+  <rect x="510" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="560" y="248" text-anchor="middle" class="label">land vehicle</text>
+  <text x="560" y="262" text-anchor="middle" class="small">car, bike, train</text>
+
+  <rect x="600" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="650" y="248" text-anchor="middle" class="label">water vehicle</text>
+  <text x="650" y="262" text-anchor="middle" class="small">boat, submarine</text>
+
+  <rect x="690" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="740" y="248" text-anchor="middle" class="label">air vehicle</text>
+  <text x="740" y="262" text-anchor="middle" class="small">plane, balloon</text>
+
+  <rect x="770" y="230" width="100" height="40" rx="6" class="box"/>
+  <text x="820" y="248" text-anchor="middle" class="label">space vehicle</text>
+  <text x="820" y="262" text-anchor="middle" class="small">rocket, probe</text>
+
+  <!-- ============ Separator ============ -->
+  <line x1="450" y1="85" x2="450" y2="290" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
+
+  <!-- ============ Footnotes ============ -->
+  <text x="440" y="320" text-anchor="middle" class="small">Two GenericHyperedges on the same genus, distinguished by criterion. Each is a distinct decomposition.</text>
+
+  <text x="440" y="345" text-anchor="middle" class="small">Within one rake, species are coordinate concepts (share genus + share criterion).</text>
+  <text x="440" y="361" text-anchor="middle" class="small">"bicycle" (human-powered) and "car" (motor-powered) are coordinate; "bicycle" and "boat" are NOT.</text>
+
+  <!-- Wire-format preview -->
+  <rect x="40" y="390" width="800" height="135" rx="4" fill="#f8f9fa" stroke="#dee2e6"/>
+  <text x="55" y="412" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/example-vehicle/by-motive-power.yaml</text>
+  <text x="55" y="428" class="small" font-family="ui-monospace, monospace">$id: example-vehicle/by-motive-power</text>
+  <text x="55" y="444" class="small" font-family="ui-monospace, monospace">type: generic_relation</text>
+  <text x="55" y="460" class="small" font-family="ui-monospace, monospace">comprehensive: { source: EXAMPLE, id: "vehicle" }</text>
+  <text x="55" y="476" class="small" font-family="ui-monospace, monospace">members:</text>
+  <text x="55" y="492" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "human-powered-vehicle" }</text>
+  <text x="55" y="508" class="small" font-family="ui-monospace, monospace">  - ref: { source: EXAMPLE, id: "animal-powered-vehicle" }</text>
+  <text x="55" y="524" class="small" font-family="ui-monospace, monospace">  - ... (motor-powered, wind-powered)</text>
+
+  <text x="455" y="428" class="small" font-family="ui-monospace, monospace">completeness: complete</text>
+  <text x="455" y="444" class="small" font-family="ui-monospace, monospace">criterion:</text>
+  <text x="455" y="460" class="small" font-family="ui-monospace, monospace">  eng: by motive power</text>
+  <text x="455" y="476" class="small" font-family="ui-monospace, monospace">  fra: par force motrice</text>
+
+  <text x="455" y="500" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># relations/example-vehicle/by-terrain.yaml — second hyperedge</text>
+  <text x="455" y="516" class="small" font-family="ui-monospace, monospace" fill="#6c757d"># same comprehensive, different criterion → distinct</text>
+</svg>

--- a/src/content/model/hyperedges.mdx
+++ b/src/content/model/hyperedges.mdx
@@ -39,6 +39,28 @@ The OIML *measurement standard* (5.1) decomposes by **multiple criteria**. Each 
 
 Two hyperedges, same comprehensive, different criteria. Species within one rake are coordinate concepts (share genus + share criterion). Species across rakes are NOT coordinate — they belong to different decompositions.
 
+### The canonical ISO 704:2022 example — optomechanical mouse
+
+ISO 704:2022 §5.5.4.2.2 uses *optomechanical mouse* as its canonical worked example. The five delimiting parts distinguish it from coordinate concepts (*mechanical mouse*, *optical mouse*); the non-delimiting parts (circuit board, button) don't; the wheel is optional:
+
+![Optomechanical mouse — ISO 704:2022 canonical partitive example](/images/hyperedge-optomechanical-mouse.svg)
+
+### Fictitious example — bicycle (partitive)
+
+A *bicycle* decomposed by physical structure, exercising every MECE dimension:
+
+![Bicycle partitive hyperedge — fictitious example](/images/hyperedge-bicycle.svg)
+
+Bold lines = delimiting (frame, wheel, handlebar distinguish bicycle from unicycle/tricycle/scooter/motorcycle). Double solid lines = `count: multiple` (typically 2 wheels, 2 pedals, 2 brakes). Dashed = `presence: optional` (bell, light). Some optional parts combine both — `optional + multiple` (light: 0, 1, or 2+).
+
+### Fictitious example — vehicle (generic)
+
+A *vehicle* genus with **two distinct criterion groups** — by motive power and by terrain:
+
+![Vehicle generic hyperedge — fictitious example with two criterion groups](/images/hyperedge-vehicle.svg)
+
+Each rake is a distinct hyperedge (distinct file under `relations/example-vehicle/`). Species within one rake are coordinate (bicycle and car share "vehicle" + "by motive power"); species across rakes are not (bicycle and boat share the genus but not a criterion).
+
 ## How they work
 
 ### MECE member multiplicity

--- a/src/content/model/hyperedges.mdx
+++ b/src/content/model/hyperedges.mdx
@@ -33,17 +33,25 @@ The VIM *measurement result* (2.9) decomposes into three parts. The diagram enco
 
 ### Generalization hyperedge example
 
-The OIML *measurement standard* (5.1) decomposes by **multiple criteria**. Each criterion is a distinct hyperedge on the same genus:
+The OIML *measurement standard* (5.1) decomposes by **multiple criteria**. Each criterion is a distinct hyperedge on the same genus, and each species carries its delimiting characteristic in a side rectangle per ISO 704:2022 §5.5.4.2.1:
 
-![Generalization hyperedge with two criterion groups](/images/hyperedge-generalization.svg)
+![Generalization hyperedge with two criterion groups and delimiting characteristics](/images/hyperedge-generalization.svg)
 
 Two hyperedges, same comprehensive, different criteria. Species within one rake are coordinate concepts (share genus + share criterion). Species across rakes are NOT coordinate — they belong to different decompositions.
 
-### The canonical ISO 704:2022 example — optomechanical mouse
+### The canonical ISO 704:2022 §5.5.4.2.1 example — computer mouse (generic)
 
-ISO 704:2022 §5.5.4.2.2 uses *optomechanical mouse* as its canonical worked example. The five delimiting parts distinguish it from coordinate concepts (*mechanical mouse*, *optical mouse*); the non-delimiting parts (circuit board, button) don't; the wheel is optional:
+ISO 704:2022 §5.5.4.2.1 uses *computer mouse* as its canonical worked example for **generic relations**. The same genus is decomposed by two distinct criteria of subdivision (multidimensionality, §5.6.3): by means of movement detection (mechanical / optomechanical / optical) and by computer connection (wired / wireless). Each species carries a delimiting characteristic:
 
-![Optomechanical mouse — ISO 704:2022 canonical partitive example](/images/hyperedge-optomechanical-mouse.svg)
+![Computer mouse — ISO 704:2022 §5.5.4.2.1 canonical generic example with multidimensionality](/images/hyperedge-computer-mouse.svg)
+
+The thicker blue and brown backlines distinguish the two criteria. The characteristic rectangles carry the intension-difference that makes each species distinct within its rake.
+
+### The canonical ISO 704:2022 §5.5.4.2.2 example — optomechanical mouse (partitive)
+
+Distinct from §5.5.4.2.1 above. The optomechanical mouse is also used as the canonical **partitive** example — its parts (mouse ball, rollers, infrared emitter/sensor, etc.) are modeled as a PartitiveHyperedge. The five delimiting parts distinguish it from coordinate concepts (*mechanical mouse*, *optical mouse*):
+
+![Optomechanical mouse — ISO 704:2022 §5.5.4.2.2 canonical partitive example](/images/hyperedge-optomechanical-mouse.svg)
 
 ### Fictitious example — bicycle (partitive)
 
@@ -165,12 +173,21 @@ AbstractHyperedge
   +notes:         LocalizedString [0..1]      # optional commentary
   +status:        ConceptStatus [0..1]        # lifecycle (independent of comprehensive)
 
-HyperedgeMember
+HyperedgeMember (abstract)
   +ref:           ConceptRef [1]
   +presence:      Presence [0..1]             # required (default) | optional
   +count:         Count [0..1]                # exactly_one (default) | at_least_one | multiple
-  +is_delimiting: Boolean [0..1]              # ISO 704 delimiting part
+  +is_delimiting: Boolean [0..1]              # ISO 704 delimiting part (partitive)
+
+GenericMember extends HyperedgeMember
+  +characteristic: LocalizedString [0..1]     # ISO 704:2022 §5.5.4.2.1 delimiting
+                                              # characteristic that distinguishes
+                                              # this species from coordinate concepts
 ```
+
+The `characteristic` field on `GenericMember` carries the **delimiting characteristic** (ISO 704:2022 §5.5.4.2.1) — the intension-difference that makes the species coordinate with its siblings within the rake. Without it, the rake is just a list of narrower concepts, not a coordinated decomposition.
+
+For partitive members, `is_delimiting` plays the analogous role (a boolean flag, no text — parts either delimit or they don't).
 
 `PartitiveHyperedge`, `GenericHyperedge`, `PartitiveMember`, `GenericMember` are thin leaf classes that inherit the shared shape. Adding a fourth n-ary type later (e.g. `SequentialHyperedge` for ISO 12620 sequential concept systems) is one class addition — no validator or schema refactor.
 
@@ -186,8 +203,14 @@ comprehensive:
   id: "5.1"
 members:
   - ref: { source: VIML, id: "5.13" }
+    characteristic:
+      eng: material sufficiently homogeneous and stable for a certified property
   - ref: { source: VIML, id: "3.2" }
+    characteristic:
+      eng: assembly of measuring instruments and auxiliary apparatus
   - ref: { source: VIML, id: "3.6" }
+    characteristic:
+      eng: device that reproduces a given quantity value during use
 completeness: complete
 criterion:
   eng: by realization medium


### PR DESCRIPTION
## Summary

Adds three SVG diagrams to the [Hyperedges model page](https://github.com/glossarist/glossarist.github.io/blob/docs/hyperedge-example-svgs/src/content/model/hyperedges.mdx), responding to "haven't you read 704:2022?" — yes, and here's the canonical example plus pedagogical fictitious ones.

### 1. The ISO 704:2022 §5.5.4.2.2 canonical example — optomechanical mouse

`public/images/hyperedge-optomechanical-mouse.svg`

ISO 704:2022 uses *optomechanical mouse* as its canonical worked example for partitive decomposition. This SVG renders it faithfully per the standard's diagram notation:
- **5 delimiting parts** (bold 3x-width): mouse ball, x-axis roller, y-axis roller, infrared emitter, infrared sensor
- **2 required non-delimiting** (solid): circuit board, mouse button
- **1 optional** (dashed): mouse wheel

The delimiting parts distinguish the comprehensive from coordinate concepts (*mechanical mouse* has no infrared emitter/sensor; *optical mouse* has no ball/rollers).

### 2. Fictitious partitive example — bicycle

`public/images/hyperedge-bicycle.svg`

Nine parts exercising every MECE dimension:
- Delimiting + required + exactly_one: frame, handlebar
- Delimiting + required + multiple: wheel (2)
- Required + multiple: pedal (2), brake (2)
- Required + exactly_one: chain, saddle
- Optional + exactly_one: bell
- Optional + multiple: light

A coordinate concept (unicycle) shown alongside for context — the delimiting parts distinguish bicycle from unicycle/tricycle/scooter/motorcycle.

### 3. Fictitious generic example — vehicle

`public/images/hyperedge-vehicle.svg`

Two distinct criterion groups on the same genus:
- **by motive power**: human-powered, animal-powered, motor-powered, wind-powered
- **by terrain**: land, water, air, space

Includes a wire-format YAML preview showing the per-file layout (`relations/example-vehicle/by-motive-power.yaml` and `by-terrain.yaml`).

## Why this matters

The canonical ISO 704 example anchors the model page to the standard. The fictitious examples make every MECE dimension visible without requiring the reader to understand VIM or OIML domain semantics first.

## Test plan

- [x] 470 vitest tests pass
- [ ] Visual review of all 7 SVGs (VIM, OIML, mouse, bicycle, vehicle, MECE, per-file storage) in light + dark mode
