### PR TITLE
docs: align hyperedge model with ISO 704 §5.5.4.2.1 + glossarist-js 0.4.34

### DIFF
--- a/public/images/hyperedge-generic-computer-mouse.svg
+++ b/public/images/hyperedge-generic-computer-mouse.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" role="img" aria-labelledby="title desc">
+  <title id="title">Generic hyperedge — computer mouse with two criteria of subdivision (ISO 704:2022 §5.5.4.2.1)</title>
+  <desc id="desc">Genus concept "computer mouse" at the top. Two distinct rakes drop from it. Left rake carries criterion "by movement detection" with three species (mechanical mouse, optomechanical mouse, optical mouse), each displaying its delimiting characteristic. Right rake carries criterion "by computer connection" with two species (wired mouse, wireless mouse), each displaying its delimiting characteristic. The two rakes share the genus but are distinct decompositions — multidimensionality per ISO 704:2022 §5.6.3.</desc>
+  <style>
+    .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
+    .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; fill: #212529; }
+    .small { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
+    .crit { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11px; fill: #0c5460; font-style: italic; }
+    .delim { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 9.5px; fill: #495057; font-style: italic; }
+    .backline { stroke: #212529; stroke-width: 2; fill: none; }
+    .tooth-solid { stroke: #212529; stroke-width: 1.5; fill: none; }
+  </style>
+
+  <!-- Genus concept (shared comprehensive) -->
+  <rect x="370" y="20" width="140" height="42" rx="6" class="box"/>
+  <text x="440" y="40" text-anchor="middle" class="label" font-weight="600">computer mouse</text>
+  <text x="440" y="55" text-anchor="middle" class="small">genus · ISO 704 §5.5.4.2.1</text>
+
+  <!-- ============ Criterion group 1: by movement detection ============ -->
+  <text x="205" y="100" text-anchor="middle" class="crit" font-weight="600">criterion: by movement detection</text>
+
+  <!-- Backline for group 1 -->
+  <line x1="30" y1="120" x2="380" y2="120" class="backline"/>
+
+  <!-- Drop lines (3 solid teeth — compulsory, exactly_one). Bold 3x-width
+       is reserved for partitive delimiting parts (§5.5.4.2.2); generic
+       species carry delimitingCharacteristic text instead. -->
+  <line x1="85" y1="120" x2="85" y2="200" class="tooth-solid"/>
+  <line x1="205" y1="120" x2="205" y2="200" class="tooth-solid"/>
+  <line x1="325" y1="120" x2="325" y2="200" class="tooth-solid"/>
+
+  <!-- Species boxes -->
+  <rect x="30" y="220" width="110" height="40" rx="6" class="box"/>
+  <text x="85" y="238" text-anchor="middle" class="label">mechanical</text>
+  <text x="85" y="252" text-anchor="middle" class="label">mouse</text>
+
+  <rect x="150" y="220" width="110" height="40" rx="6" class="box"/>
+  <text x="205" y="238" text-anchor="middle" class="label">optomechanical</text>
+  <text x="205" y="252" text-anchor="middle" class="label">mouse</text>
+
+  <rect x="270" y="220" width="110" height="40" rx="6" class="box"/>
+  <text x="325" y="238" text-anchor="middle" class="label">optical</text>
+  <text x="325" y="252" text-anchor="middle" class="label">mouse</text>
+
+  <!-- Delimiting characteristics (ISO 704 §5.5.4.2.1 Example 4) -->
+  <text x="85" y="278" text-anchor="middle" class="delim">detecting movement</text>
+  <text x="85" y="290" text-anchor="middle" class="delim">by rollers</text>
+
+  <text x="205" y="278" text-anchor="middle" class="delim">detecting movement</text>
+  <text x="205" y="290" text-anchor="middle" class="delim">by rollers + light sensors</text>
+
+  <text x="325" y="278" text-anchor="middle" class="delim">detecting movement</text>
+  <text x="325" y="290" text-anchor="middle" class="delim">by light sensors</text>
+
+  <!-- ============ Criterion group 2: by computer connection ============ -->
+  <text x="600" y="100" text-anchor="middle" class="crit" font-weight="600">criterion: by computer connection</text>
+
+  <!-- Backline for group 2 -->
+  <line x1="485" y1="120" x2="715" y2="120" class="backline"/>
+
+  <!-- Drop lines (2 solid teeth) -->
+  <line x1="540" y1="120" x2="540" y2="200" class="tooth-solid"/>
+  <line x1="660" y1="120" x2="660" y2="200" class="tooth-solid"/>
+
+  <!-- Species boxes -->
+  <rect x="485" y="220" width="110" height="40" rx="6" class="box"/>
+  <text x="540" y="238" text-anchor="middle" class="label">wired</text>
+  <text x="540" y="252" text-anchor="middle" class="label">mouse</text>
+
+  <rect x="605" y="220" width="110" height="40" rx="6" class="box"/>
+  <text x="660" y="238" text-anchor="middle" class="label">wireless</text>
+  <text x="660" y="252" text-anchor="middle" class="label">mouse</text>
+
+  <!-- Delimiting characteristics -->
+  <text x="540" y="278" text-anchor="middle" class="delim">corded electrical</text>
+  <text x="540" y="290" text-anchor="middle" class="delim">connection</text>
+
+  <text x="660" y="278" text-anchor="middle" class="delim">cordless light or</text>
+  <text x="660" y="290" text-anchor="middle" class="delim">sound connection</text>
+
+  <!-- ============ Separator ============ -->
+  <line x1="440" y1="85" x2="440" y2="300" stroke="#adb5bd" stroke-width="1" stroke-dasharray="2 4"/>
+
+  <!-- Footer legend -->
+  <text x="440" y="320" text-anchor="middle" class="small">ISO 704:2022 §5.5.4.2.1 + multidimensionality (§5.6.3) — same genus, two distinct decompositions</text>
+  <text x="440" y="336" text-anchor="middle" class="small">Each species carries a delimitingCharacteristic (text shown beneath each box) — the intension-difference from coordinate concepts</text>
+  <text x="440" y="352" text-anchor="middle" class="small">Species within one rake are coordinate concepts (share genus + share criterion, ISO 12620)</text>
+</svg>

--- a/src/content/blog/2026-07-30-hyperedges-per-file-storage.mdx
+++ b/src/content/blog/2026-07-30-hyperedges-per-file-storage.mdx
@@ -332,9 +332,9 @@ evolutionary pressure that shaped the current design.
 
 ## Further reading
 
-- [Hyperedges](/model/hyperedges) — unified model reference (with SVG diagrams)
-- [Generic Relations](/model/generic-relations) — historical reference
-- [Partitive Relations](/model/partitive-relations) — historical reference
+- [Hyperedges](/model/hyperedges) — abstract base model (with SVG diagrams)
+- [Partitive Relations](/model/partitive-relations) — whole/part specialization
+- [Generic Relations](/model/generic-relations) — genus/species specialization
 - [Relationships](/model/relationships) — binary typed edges
 - [Concepts](/model/concepts) — ManagedConcept, LocalizedConcept, ExternalConcept
 - [ISO 704](https://www.iso.org/standard/38109.html) — Terminology work: Principles and methods

--- a/src/content/model/concepts.mdx
+++ b/src/content/model/concepts.mdx
@@ -17,7 +17,7 @@ A `ManagedConcept` is the top-level concept entity in Glossarist. It represents 
 | `uri` | anyURI | 0..1 | URI for the concept |
 | `status` | [conceptStatus](/reference/entity-fields) | 0..1 | Lifecycle status |
 | `related` | [RelatedConcept](/reference/entity-fields)[] | 0..* | Related concepts |
-| `partitive_relations` | [PartitiveRelation](/model/partitive-relations)[] | 0..* | ISO 704/12620 partitive relations (one-to-many decompositions with completeness, plurality, criterion) |
+| `partitive_relations` | [PartitiveHyperedge](/model/partitive-relations)[] | 0..* | ISO 704/12620 partitive hyperedges (one-to-many whole/part decompositions with MECE presence/count, delimiting parts, completeness, subdivision criterion). Per-file storage at `relations/<id>/<slug>.yaml`. See also [Hyperedges](/model/hyperedges) for the abstract base. |
 | `dates` | [ConceptDate](/reference/entity-fields)[] | 0..* | Governance events |
 | `sources` | [ConceptSource](/model/sources)[] | 0..* | Concept-level sources |
 | `domains` | [Reference](/reference/entity-fields)[] | 0..* | Subject area references (rendered as `<domain>`) |

--- a/src/content/model/generic-relations.mdx
+++ b/src/content/model/generic-relations.mdx
@@ -1,28 +1,225 @@
 ---
-title: "Generic Relations (historical)"
-description: "Historical reference for the GenericRelation class, renamed to GenericHyperedge in Glossarist v3.3. See /model/hyperedges for the unified model."
+title: Generic Relations
+description: "GenericHyperedge — the generalization (genus/species) specialization of Hyperedge per ISO 704:2022 §5.5.4.1 / §5.5.4.2.1. Multidimensionality (§5.6.3), per-species delimiting characteristics, and the inheritance principle."
 ---
 
-# Generic Relations (historical)
+# Generic Relations
 
-> **Renamed to `GenericHyperedge`** in Glossarist v3.3.
-> The partitive vs. generic distinction is now modeled as two leaf classes
-> (`PartitiveHyperedge`, `GenericHyperedge`) of a shared `AbstractHyperedge`
-> base. The wire discriminator `type: generic_relation` is unchanged.
+`GenericHyperedge` is the generalization specialization of [`Hyperedge`](/model/hyperedges) — one comprehensive concept (the **genus**) decomposed into two or more specific concepts (the **species**) which together constitute a decomposition by some criterion of subdivision. Implements [ISO 704:2022](https://www.iso.org/standard/38109.html) §5.5.4.1 (generic concept systems) and §5.5.4.2.1 (generic relations and delimiting characteristics).
 
-The full model — MECE member multiplicity, ExternalConcept as
-comprehensive, validators, per-file storage at
-`relations/<comprehensive-id>/<criterion-slug>.yaml` — lives on the
-unified page:
+This page covers what's **unique** to generic rakes. The shared model — MECE member multiplicity, criterion of subdivision, per-file storage, ExternalConcept as comprehensive — lives on the [Hyperedges](/model/hyperedges) page.
 
-**[→ Hyperedges](/model/hyperedges)**
+## Why n-ary?
 
-For the v3.3 release announcement covering the rename, the
-generalization hyperedge, and the move to per-file storage, see
-[Hyperedges, per-file storage, and definition types](/blog/2026-07-30-hyperedges-per-file-storage).
+Most generic relations in real datasets are pairwise: binary `broader_generic` / `narrower_generic` edges suffice for "X is-a Y" assertions.
+
+`GenericHyperedge` is for the case where the source diagram shows a **rake**: one genus at the top, multiple species dropping from a shared backline, where the membership, completeness, or per-member presence/count is *jointly* significant.
+
+The trigger condition: when a real dataset has generic rakes with multiple criterion-of-subdivision groups, binary edges can't express the grouping coherently.
+
+## The canonical ISO 704:2022 example — *computer mouse*
+
+ISO 704:2022 §5.5.4.2.1 works through *computer mouse* in detail. The genus is decomposed under **two distinct criteria of subdivision** — a phenomenon ISO 704 calls **multidimensionality** (§5.6.3):
+
+- **By movement detection** → *mechanical mouse*, *optomechanical mouse*, *optical mouse*
+- **By computer connection** → *wired mouse*, *wireless mouse*
+
+Each rake is its own `GenericHyperedge` (its own file under `relations/<genus-id>/`):
+
+![Generic hyperedge — computer mouse with two criteria of subdivision (ISO 704:2022 §5.5.4.2.1)](/images/hyperedge-generic-computer-mouse.svg)
+
+Species **within one rake** are coordinate concepts (share genus + share criterion). Species **across rakes** are NOT coordinate — *optical mouse* (criterion: movement detection) and *wireless mouse* (criterion: connection) share the genus but no criterion, so they don't belong to the same coordinate set.
+
+### Per-species delimiting characteristic (ISO 704:2022 §5.5.4.2.1)
+
+ISO 704:2022 requires every species to carry at least one **delimiting characteristic** — the intension-difference that distinguishes it from coordinate concepts. For *computer mouse* under movement detection:
+
+| Species | Delimiting characteristic |
+|---------|---------------------------|
+| mechanical mouse | detecting movement by means of rollers |
+| optomechanical mouse | detecting movement by means of rollers and light sensors |
+| optical mouse | detecting movement by means of light sensors |
+
+Unlike [partitive rakes](/model/partitive-relations#delimiting-parts-iso-7042022-§55422), where `is_delimiting` is a boolean flag on `PartitiveMember` (some parts delimit, others don't), every `GenericMember` carries its delimiting characteristic **as data**: a required `delimitingCharacteristic: LocalizedString` field holding the actual text. This is the intension-difference between the species and its coordinate siblings — without it, the rake is just a list of narrower concepts, not a coordinated decomposition.
+
+`glossarist-js` enforces `delimitingCharacteristic`'s presence and non-emptiness at construction time on every `GenericMember`.
+
+### Inheritance principle (ISO 704:2022 §5.5.4.2.1 Note 1)
+
+> "If concept B is a specific concept of the generic concept A, then the intension of A is part of the intension of B."
+
+The species inherits the genus intension *plus* its delimiting characteristic. ISO 704 calls a vertical chain of generic relations a **concept ladder**; a group of coordinate concepts forms a **horizontal series**. The inheritance principle is a *validation test* for generic relations: if a putative species's intension does not include the genus intension, the relation is wrong.
+
+Glossarist does **not** materialize inherited characteristics on the species (that would duplicate the genus's definition onto every species). The inheritance principle is a reasoning pattern over correct definitions — see ["What we deliberately did not do"](/blog/2026-07-30-hyperedges-per-file-storage) in the v3.3 announcement.
+
+## Multidimensionality in real data — OIML V 2-200:2010
+
+The *computer mouse* example has 2 criteria. Real terminology vocabularies go further: OIML V 2-200:2010 carries vocabularies where a single genus is decomposed under 6 distinct criteria.
+
+| Genus | Criterion groups |
+|-------|------------------|
+| 5.1 *measurement standard* | 6 (by realization medium, by calibration role, by governance level, by metrological hierarchy, by reference/working, by travel) |
+| 1.9 *measurement unit* | 2 (by system membership, by unit multiple) |
+| *(precision condition of measurement)* [ExternalConcept] | 2 (by condition type, by precision level) |
+
+Each criterion group is a distinct `GenericHyperedge`. Without the hyperedge shape, these decompositions collapse into an undifferentiated list of binary `narrower_generic` edges with no way to say which species belong to which rake.
+
+![Generalization hyperedge — measurement standard with two criterion groups](/images/hyperedge-generalization.svg)
+
+## YAML authoring
+
+Per-file layout: `relations/<comprehensive-id>/<criterion-slug>.yaml` (see [Hyperedges — Per-file storage](/model/hyperedges#per-file-storage) for the rationale).
+
+```yaml
+# relations/example-computer-mouse/by-movement-detection.yaml
+$id: example-computer-mouse/by-movement-detection
+type: generic_relation
+status: valid
+comprehensive: { source: EXAMPLE, id: computer-mouse }
+members:
+  - ref: { source: EXAMPLE, id: mechanical-mouse }
+    delimitingCharacteristic: { eng: detecting movement by means of rollers }
+  - ref: { source: EXAMPLE, id: optomechanical-mouse }
+    delimitingCharacteristic: { eng: detecting movement by means of rollers and light sensors }
+  - ref: { source: EXAMPLE, id: optical-mouse }
+    delimitingCharacteristic: { eng: detecting movement by means of light sensors }
+completeness: complete
+criterion: { eng: by movement detection }
+sources:
+  - type: authoritative
+    origin:
+      ref: { source: ISO, id: "704:2022" }
+      locality: { type: figure, reference_from: "§5.5.4.2.1 Example 4" }
+```
+
+The companion rake lives next to it:
+
+```yaml
+# relations/example-computer-mouse/by-computer-connection.yaml
+$id: example-computer-mouse/by-computer-connection
+type: generic_relation
+status: valid
+comprehensive: { source: EXAMPLE, id: computer-mouse }
+members:
+  - ref: { source: EXAMPLE, id: wired-mouse }
+    delimitingCharacteristic: { eng: using a corded electrical connection }
+  - ref: { source: EXAMPLE, id: wireless-mouse }
+    delimitingCharacteristic: { eng: using a cordless light or sound connection }
+completeness: complete
+criterion: { eng: by computer connection }
+sources:
+  - type: authoritative
+    origin:
+      ref: { source: ISO, id: "704:2022" }
+      locality: { type: figure, reference_from: "§5.5.4.2.1 Example 4" }
+```
+
+The directory `relations/example-computer-mouse/` IS the index — every criterion group on `computer-mouse` enumerated as a sibling file.
+
+### OIML-scale example
+
+```yaml
+# relations/viml-5-1/by-realization-medium.yaml
+$id: viml-5-1/by-realization-medium
+type: generic_relation
+status: valid
+comprehensive:
+  source: VIML
+  id: "5.1"
+members:
+  - ref: { source: VIML, id: "5.13" }
+    delimitingCharacteristic: { eng: material sufficiently homogeneous and stable for a certified property }
+  - ref: { source: VIML, id: "3.2" }
+    delimitingCharacteristic: { eng: assembly of measuring instruments and auxiliary apparatus }
+  - ref: { source: VIML, id: "3.6" }
+    delimitingCharacteristic: { eng: device that reproduces a given quantity value during use }
+completeness: complete
+criterion:
+  eng: by realization medium
+  fra: par milieu de réalisation
+sources:
+  - type: authoritative
+    origin:
+      ref: { source: OIML, id: "V 2-200:2010" }
+      locality: { type: figure, reference_from: "5.1/Fig.1" }
+```
+
+The same genus carries 5 more hyperedges (one per remaining criterion group), each in its own file under `relations/viml-5-1/`.
+
+## Field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `$id` | string | `<comprehensive-id>/<criterion-slug>` — must match file path |
+| `type` | enum | `generic_relation` (wire discriminator) |
+| `comprehensive` | ConceptRef | The genus concept |
+| `members` | `GenericMember[2..*]` | The species concepts |
+| `completeness` | `complete` \| `partial` | Default: `complete` |
+| `criterion` | LocalizedString | ISO 12620 subdivision principle (disambiguates rakes on the same genus — multidimensionality) |
+| `sources` | ConceptSource[] | Bibliographic provenance |
+| `notes` | LocalizedString | Optional commentary |
+| `status` | ConceptStatus | Lifecycle (independent of genus) |
+
+### GenericMember fields
+
+`GenericMember` extends [`HyperedgeMember`](/model/hyperedges#model) with one required field:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ref` | ConceptRef | The species concept (inherited from `HyperedgeMember`) |
+| `presence` | `required` \| `optional` | ISO 704 line style; default `required` (inherited) |
+| `count` | `exactly_one` \| `at_least_one` \| `multiple` | ISO 704 line count; default `exactly_one` (inherited) |
+| `delimitingCharacteristic` | LocalizedString | **Required** — ISO 704 §5.5.4.2.1 intension-difference from coordinate concepts |
+
+The shared MECE dimensions (`presence`, `count`) are documented under [Hyperedges — MECE member multiplicity](/model/hyperedges#mece-member-multiplicity).
+
+## RDF emission
+
+```turtle
+<concept/example-computer-mouse> gloss:hasGenericHyperedge [
+  a gloss:GenericHyperedge ;
+  gloss:comprehensive <concept/example-computer-mouse> ;
+  gloss:hasGeneric
+    [ a gloss:GenericMember ; gloss:ref <concept/mechanical-mouse> ;
+      gloss:delimitingCharacteristic "detecting movement by means of rollers"@en ] ,
+    [ a gloss:GenericMember ; gloss:ref <concept/optomechanical-mouse> ;
+      gloss:delimitingCharacteristic "detecting movement by means of rollers and light sensors"@en ] ,
+    [ a gloss:GenericMember ; gloss:ref <concept/optical-mouse> ;
+      gloss:delimitingCharacteristic "detecting movement by means of light sensors"@en ] ;
+  gloss:completeness <completeness/complete> ;
+  gloss:criterion "by movement detection"@en ;
+] .
+```
+
+## Validation
+
+The `check-generic-relation-coherence` validator (and `glossarist-js` construction-time checks) enforces generic-specific invariants:
+
+- Cardinality: ≥ 2 species per rake (ISO 704 "two or more")
+- `delimitingCharacteristic` required on every `GenericMember` (ISO 704 §5.5.4.2.1)
+- No duplicate `(comprehensive, criterion)` pairs on the same genus
+- Invalid MECE combo (`optional + at_least_one`) rejected
+- Warning when a genus has 2+ rakes and any lack `criterion` — multidimensionality can't be verified without it
+
+Shared validation rules are listed under [Hyperedges — Validators](/model/hyperedges#validators).
+
+## Relation to PartitiveHyperedge
+
+| | PartitiveHyperedge | GenericHyperedge |
+|---|---|---|
+| `comprehensive` means | the whole | the genus |
+| `members` are | parts | species |
+| ISO 704 section | §5.5.4.3 / §5.5.4.2.2 | §5.5.4.1 / §5.5.4.2.1 |
+| Member delimiting semantics | `is_delimiting: boolean` (optional flag — some parts delimit) | `delimitingCharacteristic: LocalizedString` (required text — every species carries one) |
+| Wire shape | identical | identical |
+| Validators | shared (`NaryCoherence`) | shared |
+
+The split between `is_delimiting` (on `PartitiveMember`) and `delimitingCharacteristic` (on `GenericMember`) is deliberate — the two leaves model genuinely different ISO 704 semantics, not a flag-vs-text rendering of the same concept. The abstract `HyperedgeMember` carries only the shared MECE pair; each leaf adds its own delimiting dimension.
 
 ## See also
 
-- [Hyperedges](/model/hyperedges) — unified model reference
-- [Partitive Relations (historical)](/model/partitive-relations) — whole/part mirror
-- [Relationships](/model/relationships) — binary typed edges
+- [Hyperedges](/model/hyperedges) — abstract base model (shared MECE, per-file storage, ExternalConcept)
+- [Partitive Relations](/model/partitive-relations) — whole/part specialization
+- [Relationships](/model/relationships) — binary typed edges (`broader_generic`, `narrower_generic`, etc.)
+- [Concepts](/model/concepts) — ManagedConcept, LocalizedConcept, ExternalConcept
+- [ISO 704:2022](https://www.iso.org/standard/38109.html) §5.5.4.1, §5.5.4.2.1, §5.6.3 — generic concept systems, generic relations, multidimensionality

--- a/src/content/model/hyperedges.mdx
+++ b/src/content/model/hyperedges.mdx
@@ -78,7 +78,7 @@ ISO 704:2022 encodes per-member multiplicity via diagram line notation. Glossari
 - **Presence** (`required` | `optional`) — line style
 - **Count** (`exactly_one` | `at_least_one` | `multiple`) — line count
 
-A third orthogonal flag — **is_delimiting** (boolean) — encodes the bold 3x-width line.
+The bold 3x-width line in ISO 704 diagrams is **not** a third MECE axis — it's modeled differently per leaf (`is_delimiting: boolean` on `PartitiveMember` for delimiting parts, `delimitingCharacteristic: LocalizedString` on `GenericMember` for the species intension-difference). See [Model](#model) below.
 
 ![MECE member multiplicity table](/images/hyperedge-mece-multiplicity.svg)
 
@@ -173,21 +173,25 @@ AbstractHyperedge
   +notes:         LocalizedString [0..1]      # optional commentary
   +status:        ConceptStatus [0..1]        # lifecycle (independent of comprehensive)
 
-HyperedgeMember (abstract)
+HyperedgeMember (abstract — shared MECE dimensions only)
   +ref:           ConceptRef [1]
   +presence:      Presence [0..1]             # required (default) | optional
   +count:         Count [0..1]                # exactly_one (default) | at_least_one | multiple
-  +is_delimiting: Boolean [0..1]              # ISO 704 delimiting part (partitive)
+
+PartitiveMember extends HyperedgeMember
+  +is_delimiting: Boolean [0..1]              # ISO 704 §5.5.4.2.2 delimiting part (default: false)
 
 GenericMember extends HyperedgeMember
-  +characteristic: LocalizedString [0..1]     # ISO 704:2022 §5.5.4.2.1 delimiting
-                                              # characteristic that distinguishes
-                                              # this species from coordinate concepts
+  +delimitingCharacteristic: LocalizedString [1]  # REQUIRED — ISO 704 §5.5.4.2.1 intension difference
 ```
 
-The `characteristic` field on `GenericMember` carries the **delimiting characteristic** (ISO 704:2022 §5.5.4.2.1) — the intension-difference that makes the species coordinate with its siblings within the rake. Without it, the rake is just a list of narrower concepts, not a coordinated decomposition.
+The split is deliberate:
 
-For partitive members, `is_delimiting` plays the analogous role (a boolean flag, no text — parts either delimit or they don't).
+- **`HyperedgeMember` carries only the shared MECE pair (`presence` × `count`).** These are the dimensions every n-ary member has regardless of hyperedge type.
+- **`PartitiveMember` adds `is_delimiting: boolean`** — a partitive-specific flag (ISO 704 §5.5.4.2.2) marking parts that behave like delimiting characteristics. Not all parts delimit, so the flag carries real information; rendered as the bold 3x-width line in source diagrams.
+- **`GenericMember` adds `delimitingCharacteristic: LocalizedString` (required)** — per ISO 704 §5.5.4.2.1, every species carries at least one delimiting characteristic (the intension-difference from coordinate concepts). Generic members don't get a boolean flag — they get the *text itself*, because the text is the data.
+
+Construction-time validation in `glossarist-js` enforces `delimitingCharacteristic`'s presence and non-emptiness on every `GenericMember`.
 
 `PartitiveHyperedge`, `GenericHyperedge`, `PartitiveMember`, `GenericMember` are thin leaf classes that inherit the shared shape. Adding a fourth n-ary type later (e.g. `SequentialHyperedge` for ISO 12620 sequential concept systems) is one class addition — no validator or schema refactor.
 
@@ -203,13 +207,13 @@ comprehensive:
   id: "5.1"
 members:
   - ref: { source: VIML, id: "5.13" }
-    characteristic:
+    delimitingCharacteristic:
       eng: material sufficiently homogeneous and stable for a certified property
   - ref: { source: VIML, id: "3.2" }
-    characteristic:
+    delimitingCharacteristic:
       eng: assembly of measuring instruments and auxiliary apparatus
   - ref: { source: VIML, id: "3.6" }
-    characteristic:
+    delimitingCharacteristic:
       eng: device that reproduces a given quantity value during use
 completeness: complete
 criterion:

--- a/src/content/model/partitive-relations.mdx
+++ b/src/content/model/partitive-relations.mdx
@@ -1,28 +1,153 @@
 ---
-title: "Partitive Relations (historical)"
-description: "Historical reference for the PartitiveRelation class, renamed to PartitiveHyperedge in Glossarist v3.3. See /model/hyperedges for the unified model."
+title: Partitive Relations
+description: "PartitiveHyperedge — the partitive (whole/part) specialization of Hyperedge per ISO 704:2022 §5.5.4.3. Delimiting parts, completeness, the canonical optomechanical mouse example, partitive-specific YAML/RDF."
 ---
 
-# Partitive Relations (historical)
+# Partitive Relations
 
-> **Renamed to `PartitiveHyperedge`** in Glossarist v3.3.
-> The partitive vs. generic distinction is now modeled as two leaf classes
-> (`PartitiveHyperedge`, `GenericHyperedge`) of a shared `AbstractHyperedge`
-> base. The wire discriminator `type: partitive_relation` is unchanged.
+`PartitiveHyperedge` is the partitive specialization of [`Hyperedge`](/model/hyperedges) — one comprehensive concept (the **whole**) decomposed into two or more partitive concepts (the **parts**) which fitted together constitute the comprehensive. Implements [ISO 704:2022](https://www.iso.org/standard/38109.html) §5.5.4.3.
 
-The full model — MECE member multiplicity, ExternalConcept as
-comprehensive, validators, per-file storage at
-`relations/<comprehensive-id>/<criterion-slug>.yaml` — lives on the
-unified page:
+This page covers what's **unique** to partitive rakes. The shared model — MECE member multiplicity, criterion of subdivision, per-file storage, ExternalConcept as comprehensive — lives on the [Hyperedges](/model/hyperedges) page.
 
-**[→ Hyperedges](/model/hyperedges)**
+## ISO 704:2022 terminology
 
-For the v3.3 release announcement covering the rename, the
-generalization parallel, and the move to per-file storage, see
-[Hyperedges, per-file storage, and definition types](/blog/2026-07-30-hyperedges-per-file-storage).
+| Role | ISO term |
+|------|----------|
+| The whole concept | comprehensive concept (superordinate concept partitive) |
+| Each part concept | partitive concept (subordinate concept partitive) |
+| The relation | partitive relation |
+| Siblings in one rake | coordinate concepts |
+
+All parts within one PartitiveHyperedge are **coordinate concepts** (ISO 12620): they share the comprehensive AND the criterion of subdivision.
+
+## Delimiting parts (ISO 704:2022 §5.5.4.2.2)
+
+A **delimiting part** behaves like a delimiting characteristic: it distinguishes the comprehensive from coordinate concepts. In ISO 704 diagrams, delimiting parts are drawn with a bold (3x-width) line. The `is_delimiting: true` flag on a `PartitiveMember` encodes this — `PartitiveMember` is the only place this flag lives (it's partitive-specific per ISO 704 §5.5.4.2.2; generic members carry `delimitingCharacteristic` text instead, see [Generic Relations](/model/generic-relations#per-species-delimiting-characteristic-iso-7042022-§55421)).
+
+Delimiting is **orthogonal** to presence and count — a delimiting part can be compulsory, optional, or any other multiplicity. See the [MECE multiplicity table](/model/hyperedges#mece-member-multiplicity) on the Hyperedges page.
+
+**Canonical example** (ISO 704:2022 §5.5.4.2.2): for "optomechanical mouse":
+
+| Part | Delimiting? | Why? |
+|------|-------------|------|
+| mouse ball | yes | distinguishes from optical mice |
+| x-axis roller | yes | distinguishes from optical mice |
+| y-axis roller | yes | distinguishes from optical mice |
+| infrared emitter | yes | distinguishes from mechanical mice |
+| infrared sensor | yes | distinguishes from mechanical mice |
+| circuit board | no | all mice have circuit boards |
+| mouse button | no | all computer mice have buttons |
+| mouse wheel | no | not found on all optomechanical mice (optional) |
+
+![Optomechanical mouse — ISO 704:2022 canonical partitive example](/images/hyperedge-optomechanical-mouse.svg)
+
+## YAML authoring
+
+Per-file layout: `relations/<comprehensive-id>/<criterion-slug>.yaml` (see [Hyperedges — Per-file storage](/model/hyperedges#per-file-storage) for the rationale).
+
+```yaml
+# relations/viml-112-02-09/measurement-result-composition.yaml
+$id: viml-112-02-09/measurement-result-composition
+type: partitive_relation
+status: valid
+comprehensive:
+  source: VIM
+  id: "112-02-09"
+members:
+  - ref: { source: VIM, id: "112-02-10" }
+  - ref: { source: VIM, id: "112-03-26" }
+completeness: complete
+criterion:
+  eng: measurement result composition
+```
+
+### Optomechanical mouse (ISO 704:2022 §5.5.4.2.2)
+
+```yaml
+# relations/example-optomechanical-mouse/physical-component-decomposition.yaml
+$id: example-optomechanical-mouse/physical-component-decomposition
+type: partitive_relation
+status: valid
+comprehensive: { source: EXAMPLE, id: optomechanical-mouse }
+members:
+  - ref: { source: EXAMPLE, id: mouse-ball }
+    is_delimiting: true
+  - ref: { source: EXAMPLE, id: x-axis-roller }
+    is_delimiting: true
+  - ref: { source: EXAMPLE, id: y-axis-roller }
+    is_delimiting: true
+  - ref: { source: EXAMPLE, id: infrared-emitter }
+    is_delimiting: true
+  - ref: { source: EXAMPLE, id: infrared-sensor }
+    is_delimiting: true
+  - ref: { source: EXAMPLE, id: circuit-board }
+  - ref: { source: EXAMPLE, id: mouse-button }
+  - ref: { source: EXAMPLE, id: mouse-wheel }
+    presence: optional
+completeness: complete
+criterion:
+  eng: physical component decomposition
+```
+
+Mouse wheel has `presence: optional` (not found on all optomechanical mice). The five delimiting parts distinguish "optomechanical mouse" from coordinate concepts "mechanical mouse" and "optical mouse".
+
+### Two decompositions of the same comprehensive
+
+A comprehensive can carry multiple partitive hyperedges, each with its own criterion:
+
+```yaml
+# relations/example-bicycle/by-physical-structure.yaml
+$id: example-bicycle/by-physical-structure
+type: partitive_relation
+comprehensive: { source: EXAMPLE, id: bicycle }
+members:
+  - ref: { source: EXAMPLE, id: frame }
+  - ref: { source: EXAMPLE, id: wheels }
+completeness: complete
+criterion: { eng: physical structure }
+
+# relations/example-bicycle/by-functional-subsystem.yaml
+$id: example-bicycle/by-functional-subsystem
+type: partitive_relation
+comprehensive: { source: EXAMPLE, id: bicycle }
+members:
+  - ref: { source: EXAMPLE, id: structural }
+  - ref: { source: EXAMPLE, id: propulsion }
+completeness: complete
+criterion: { eng: functional subsystem }
+```
+
+The coherence validator rejects duplicate `(comprehensive, criterion)` pairs as errors.
+
+## RDF emission
+
+```turtle
+<concept/optomechanical-mouse> gloss:hasPartitiveHyperedge [
+  a gloss:PartitiveHyperedge ;
+  gloss:comprehensive <concept/optomechanical-mouse> ;
+  gloss:hasPartitive
+    [ a gloss:PartitiveMember ; gloss:ref <concept/mouse-ball> ; gloss:isDelimiting true ] ,
+    [ a gloss:PartitiveMember ; gloss:ref <concept/mouse-wheel> ; gloss:presence <partitivePresence/optional> ] ;
+  gloss:completeness <completeness/complete> ;
+  gloss:criterion "physical component decomposition"@en ;
+] .
+```
+
+## Validation
+
+The `check-partitive-relation-coherence` validator enforces partitive-specific invariants:
+
+- Cardinality: ≥ 2 partitive members per rake (ISO 704 "two or more")
+- No duplicate `(comprehensive, criterion)` pairs
+- Invalid MECE combo (`optional + at_least_one`) rejected
+- Warning on `is_delimiting: true` + `presence: optional` — a delimiting part that's optional is semantically incoherent
+
+Shared validation rules (criterion-of-subdivision coherence, ExternalConcept-as-comprehensive, relation-file-shape) are listed under [Hyperedges — Validators](/model/hyperedges#validators).
 
 ## See also
 
-- [Hyperedges](/model/hyperedges) — unified model reference
-- [Generic Relations (historical)](/model/generic-relations) — genus/species mirror
-- [Relationships](/model/relationships) — binary typed edges
+- [Hyperedges](/model/hyperedges) — abstract base model (shared MECE, per-file storage, ExternalConcept)
+- [Generic Relations](/model/generic-relations) — genus/species specialization
+- [Relationships](/model/relationships) — binary typed edges (`has_part`, `is_part_of`, etc.)
+- [Concepts](/model/concepts) — ManagedConcept, LocalizedConcept, ExternalConcept
+- [ISO 704:2022](https://www.iso.org/standard/38109.html) §5.5.4.3 — partitive concept systems

--- a/src/content/model/relationships.mdx
+++ b/src/content/model/relationships.mdx
@@ -60,46 +60,45 @@ related:
 
 <figure>
   <img src="/images/model/relations/binary-has-part.svg" alt="Two concept boxes connected by a labeled arrow. The left box 'bicycle' points to the right box 'wheel' via an arrow labeled 'has_part' (inverse: is_part_of)." loading="lazy" />
-  <figcaption>Binary partitive edge. Use for single pairwise assertions without completeness or plurality claims.</figcaption>
+  <figcaption>Binary partitive edge. Use for single pairwise assertions without completeness or multiplicity claims.</figcaption>
 </figure>
 
 ### Partitive relations (n-ary)
 
 When a partitive decomposition is *one-to-many* and the membership,
-completeness, or type-shared plurality is jointly significant, use
-a `PartitiveRelation` (ISO 704) instead of N binary `has_part` /
-`is_part_of` edges. Relations carry:
+completeness, or per-member multiplicity is jointly significant, use
+a `PartitiveHyperedge` (ISO 704:2022 §5.5.4.3) instead of N binary
+`has_part` / `is_part_of` edges. Each hyperedge carries:
 
-- `completeness` — `complete` (partitives fitted together constitute
-  the comprehensive) or `partial` (others exist beyond those encoded)
-- `plurality` — ISO 704's close-set double line and broken line as
-  structured data (`is_shared`, `is_uncertain`, optional `shared_type`)
+- `completeness` — `complete` (parts fitted together constitute the
+  comprehensive) or `partial` (others exist beyond those encoded)
 - `criterion` — ISO 12620 subdivision criterion for coordinate-concept
   coherence
-- per-partitive `certainty` — confirmed (default) or possible
-  (Glossarist extension)
+- per-member **MECE multiplicity** — `presence` (`required` | `optional`)
+  × `count` (`exactly_one` | `at_least_one` | `multiple`), plus the
+  orthogonal `is_delimiting` flag (ISO 704 bold 3x-width line)
 
 ```yaml
-partitive_relations:
-  - comprehensive: { source: VIM, id: "112-02-09" }
-    partitives:
-      - ref: { source: VIM, id: "112-02-10" }
-      - ref: { source: VIM, id: "112-03-26" }
-    completeness: complete
-    plurality:
-      is_shared: true        # ISO 704 close-set double line
-    criterion:
-      eng: measurement result composition
+# relations/viml-112-02-09/measurement-result-composition.yaml
+$id: viml-112-02-09/measurement-result-composition
+type: partitive_relation
+comprehensive: { source: VIM, id: "112-02-09" }
+members:
+  - ref: { source: VIM, id: "112-02-10" }
+  - ref: { source: VIM, id: "112-03-26" }
+completeness: complete
+criterion: { eng: measurement result composition }
 ```
 
-ISO 704 requires **two or more** partitives per relation. A single
-partitive should be expressed as a binary `has_part` edge instead.
+ISO 704 requires **two or more** parts per rake. A single partitive
+assertion should be expressed as a binary `has_part` edge instead.
 
 Both shapes coexist on the same concept — no automatic consolidation
-is performed. The `check-binary-has-part-redundancy` validator
-warns when binary `has_part` edges duplicate a PartitiveRelation's
-assertions. See [Partitive Relations](/model/partitive-relations)
-for the full model, YAML authoring, RDF emission, and validation rules.
+is performed. The `check-binary-has-part-redundancy` validator warns
+when binary `has_part` edges duplicate a `PartitiveHyperedge`'s
+assertions. See [Partitive Relations](/model/partitive-relations) for
+the full model, YAML authoring, RDF emission, and validation rules,
+and [Hyperedges](/model/hyperedges) for the shared abstract base.
 
 <figure>
   <img src="/images/model/relations/generic-tree.svg" alt="ISO 704 generic-relation tree. A superordinate concept 'measurement unit' at the top branches down to 'SI unit' and 'off-system unit', with three dots indicating more specific concepts exist." loading="lazy" />

--- a/src/data/sidebars.ts
+++ b/src/data/sidebars.ts
@@ -21,6 +21,8 @@ export const sidebars: Record<string, SidebarGroup[]> = {
         { text: 'Designations', link: '/model/designations' },
         { text: 'Relationships', link: '/model/relationships' },
         { text: 'Hyperedges', link: '/model/hyperedges' },
+        { text: 'Partitive Relations', link: '/model/partitive-relations' },
+        { text: 'Generic Relations', link: '/model/generic-relations' },
         { text: 'Sources', link: '/model/sources' },
         { text: 'Datasets & Sections', link: '/model/datasets' },
         { text: 'Non-verbal Entities', link: '/model/non-verbal' },

--- a/test/content-references.test.ts
+++ b/test/content-references.test.ts
@@ -127,21 +127,27 @@ describe('Hyperedges content (PR #86)', () => {
     expect(html).toContain('HyperedgeMember')
   })
 
-  it('partitive-relations.mdx has a banner pointing to the unified page', () => {
+  it('partitive-relations.mdx frames as a specialization of Hyperedges', () => {
     const src = readSource('model/partitive-relations.mdx')
-    expect(src).toMatch(/\[Hyperedges\]\(\/model\/hyperedges\)/)
+    expect(src).toMatch(/specialization of \[?`?Hyperedge/)
+    expect(src).toMatch(/PartitiveHyperedge/)
+    expect(src).not.toMatch(/historical reference/i)
+    expect(src).not.toMatch(/Renamed to `PartitiveHyperedge`/)
   })
 
-  it('generic-relations.mdx has a banner pointing to the unified page', () => {
+  it('generic-relations.mdx frames as a specialization of Hyperedges', () => {
     const src = readSource('model/generic-relations.mdx')
-    expect(src).toMatch(/\[Hyperedges\]\(\/model\/hyperedges\)/)
+    expect(src).toMatch(/specialization of \[?`?Hyperedge/)
+    expect(src).toMatch(/GenericHyperedge/)
+    expect(src).not.toMatch(/historical reference/i)
+    expect(src).not.toMatch(/Renamed to `GenericHyperedge`/)
   })
 
-  it('sidebar lists Hyperedges (unified page only; historical stubs reachable via links)', () => {
+  it('sidebar lists Hyperedges (abstract) plus the two specialized leaves', () => {
     const sidebars = readFileSync(join(root, 'src/data/sidebars.ts'), 'utf-8')
     expect(sidebars).toContain("/model/hyperedges")
-    expect(sidebars).not.toContain("/model/partitive-relations")
-    expect(sidebars).not.toContain("/model/generic-relations")
+    expect(sidebars).toContain("/model/partitive-relations")
+    expect(sidebars).toContain("/model/generic-relations")
   })
 
   it('every hyperedge SVG referenced from MDX exists in public/', () => {
@@ -150,6 +156,7 @@ describe('Hyperedges content (PR #86)', () => {
       'hyperedge-generalization.svg',
       'hyperedge-mece-multiplicity.svg',
       'hyperedge-per-file-storage.svg',
+      'hyperedge-generic-computer-mouse.svg',
     ]
     for (const name of expected) {
       const path = join(publicDir, 'images', name)
@@ -157,13 +164,14 @@ describe('Hyperedges content (PR #86)', () => {
     }
   })
 
-  it('hyperedges SVGs include accessibility title + desc', () => {
+  it('every hyperedge SVG includes accessibility title + desc', () => {
     // Each SVG must carry role="img" plus <title> + <desc> for SR support.
     const expected = [
       'hyperedge-partitive.svg',
       'hyperedge-generalization.svg',
       'hyperedge-mece-multiplicity.svg',
       'hyperedge-per-file-storage.svg',
+      'hyperedge-generic-computer-mouse.svg',
     ]
     for (const name of expected) {
       const svg = readFileSync(join(publicDir, 'images', name), 'utf-8')


### PR DESCRIPTION
## Summary

Aligns the Glossarist hyperedge model documentation with the actual implementation in [glossarist-js](https://github.com/glossarist/glossarist-js) 0.4.34 and [concept-browser](https://github.com/glossarist/concept-browser), and with ISO 704:2022 §5.5.4.2.1 (generic relations and delimiting characteristics).

### Model split — `HyperedgeMember` no longer carries delimiting fields

Mirrors `glossarist-js/src/models/*.js`:

```
HyperedgeMember (abstract — shared MECE pair only)
  +ref, +presence, +count

PartitiveMember extends HyperedgeMember
  +is_delimiting: Boolean                      # ISO 704 §5.5.4.2.2 (some parts)

GenericMember extends HyperedgeMember
  +delimitingCharacteristic: LocalizedString   # ISO 704 §5.5.4.2.1 (REQUIRED on every species)
```

The split is deliberate. The two leaves model genuinely different ISO 704 semantics — they're not flag-vs-text renderings of the same concept. `glossarist-js` enforces `delimitingCharacteristic`'s presence and non-emptiness at construction time on every `GenericMember`.

### ISO 704:2022 §5.5.4.2.1 canonical example

Adds the standard's worked example: *computer mouse* with two distinct criteria of subdivision (multidimensionality, §5.6.3):

- **By movement detection** → mechanical mouse, optomechanical mouse, optical mouse
- **By computer connection** → wired mouse, wireless mouse

Each species carries its `delimitingCharacteristic` text. Species within a rake are coordinate concepts; species across rakes share the genus but no criterion — they are NOT coordinate.

New SVG: `public/images/hyperedge-generic-computer-mouse.svg` shows the two-rake multidimensionality with per-species delimiting characteristic text. Uses normal solid lines (the bold-line convention is partitive-only per §5.5.4.2.2).

### Stale terminology cleanup

- `concepts.mdx` — `PartitiveRelation` + `plurality` (v2) → `PartitiveHyperedge` + MECE (v3) on the `partitive_relations` field row
- `relationships.mdx` — "Partitive relations (n-ary)" section rewritten: v2 fields replaced with v3 MECE shape; per-file YAML example

### Specialization IA fix

Restores Partitive Relations and Generic Relations entries in the sidebar. The two pages are specialized leaves of the hyperedge abstraction (mirroring `PartitiveMember`/`GenericMember` in code), not historical stubs.

### Test invariants

`test/content-references.test.ts` updated to verify:
- Leaf pages frame as `specialization of Hyperedge` (not `historical reference`)
- Sidebar lists Hyperedges + both specialized leaves
- New SVG passes accessibility invariants (`<title>`, `<desc>`, `role="img"`)

## Test plan

- [x] `npm run build` passes — 86 pages built
- [x] `npm test` passes — 470 tests
- [x] No AI attribution in commit message
- [ ] Preview deployment shows the new SVG rendering correctly
- [ ] Cross-references between leaf pages and the abstract page resolve

## Lockstep

Companion to glossarist-js 0.4.34 (`delimitingCharacteristic` on `GenericMember`) and concept-browser 0.7.93+ (`feat: delimitingCharacteristic support`).
