### PR TITLE
docs: surface use cases on homepage + add JSON-LD structured data

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -361,7 +361,7 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
           <span class="g-label-text">In Production</span>
         </div>
         <h2 class="hp-section-title">Trusted by <em>standards bodies</em>.</h2>
-        <p class="g-lede" style="margin-bottom: 3rem;">Glossarist powers multilingual terminology registries for international standards organizations.</p>
+        <p class="g-lede" style="margin-bottom: 3rem;">Glossarist powers multilingual terminology registries for international standards organizations. <a href="/use-cases/" class="hp-inline-link">Read the use cases →</a></p>
 
         <div class="g-card-grid g-card-grid-2">
           <a href="https://isotc211.geolexica.org/" target="_blank" rel="noopener" class="g-card hp-user-card">
@@ -422,6 +422,7 @@ collection.to_skos(<span class="c-str">'output.ttl'</span>)`,
         <h2 class="hp-cta-title">Start building your<br /><em>concept system</em>.</h2>
         <div class="hp-cta-actions">
           <a href="/docs/adopt/" class="g-cta">Adoption Guide →</a>
+          <a href="/use-cases/" class="g-cta g-cta-light">Read Use Cases</a>
           <a href="/docs/software/desktop" class="g-cta g-cta-light">Download Desktop App</a>
           <a href="https://github.com/glossarist" class="g-cta g-cta-light" target="_blank" rel="noopener">Browse Source</a>
         </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,13 +13,52 @@ interface Props {
 
 const { title, description = 'Open-source software for maintaining multi-language concept systems', fullscreen = false } = Astro.props
 const pageTitle = title === 'Glossarist' ? title : `${title} | Glossarist`
+const canonical = new URL(Astro.url.pathname, Astro.site ?? 'https://www.glossarist.org').toString()
+
+// JSON-LD structured data: TechArticle for docs/reference/model pages,
+// WebSite for the homepage. Helps search engines understand that this
+// is technical documentation about terminology standards.
+const isHome = Astro.url.pathname === '/'
+const orgLd = {
+  '@type': 'Organization',
+  name: 'Glossarist',
+  url: 'https://www.glossarist.org/',
+  logo: 'https://www.glossarist.org/logo-glossarist.svg',
+  sameAs: ['https://github.com/glossarist'],
+}
+const structured = isHome
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'Glossarist',
+      url: 'https://www.glossarist.org/',
+      description,
+      publisher: orgLd,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://www.glossarist.org/?q={search_term_string}',
+        'query-input': 'required name=search_term_string',
+      },
+    }
+  : {
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      headline: title,
+      description,
+      url: canonical,
+      inLanguage: 'en-US',
+      publisher: orgLd,
+      about: ['Terminology management', 'ISO 704', 'ISO 10241-1', 'Concept systems'],
+    }
 ---
+
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico" />
@@ -34,6 +73,7 @@ const pageTitle = title === 'Glossarist' ? title : `${title} | Glossarist`
       const dark = stored === 'dark' || ((!stored || stored === 'auto') && prefersDark)
       if (dark) document.documentElement.classList.add('dark')
     </script>
+    <script type="application/ld+json" set:html={JSON.stringify(structured)} />
   </head>
   <body class={fullscreen ? 'fullscreen-page' : ''}>
     <Nav />

--- a/test/content-references.test.ts
+++ b/test/content-references.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { resolve, join, dirname } from 'node:path'
-import { root } from './_helpers'
+import { root, readBuilt } from './_helpers'
 
 const contentDir = join(root, 'src/content')
 const publicDir = join(root, 'public')
@@ -276,6 +276,46 @@ describe('Use cases collection', () => {
       .sort((a, b) => a.order - b.order)
     // Metrology should be order=1 (the canonical example)
     expect(cases[0].f).toBe('metrology.mdx')
+  })
+})
+
+describe('SEO invariants (JSON-LD + canonical)', () => {
+  // Locks in structured-data emission. JSON-LD helps search engines
+  // understand this is a TechArticle / WebSite; canonical prevents
+  // duplicate-content penalties from trailing-slash variants.
+
+  it('homepage emits WebSite JSON-LD with SearchAction', () => {
+    const html = readBuilt('dist/index.html')
+    expect(html).toMatch(/<script[^>]*application\/ld\+json[^>]*>/)
+    expect(html).toMatch(/"@type":"WebSite"/)
+    expect(html).toMatch(/SearchAction/)
+  })
+
+  it('docs/reference pages emit TechArticle JSON-LD', () => {
+    const cases = [
+      'dist/model/hyperedges/index.html',
+      'dist/model/concept-system-types/index.html',
+      'dist/model/definitions/index.html',
+      'dist/reference/iso-10241-1-mapping/index.html',
+      'dist/use-cases/metrology/index.html',
+    ]
+    for (const path of cases) {
+      const html = readBuilt(path)
+      expect(html, `${path} missing JSON-LD`).toMatch(/<script[^>]*application\/ld\+json[^>]*>/)
+      expect(html, `${path} not TechArticle`).toMatch(/"@type":"TechArticle"/)
+    }
+  })
+
+  it('every page has a canonical URL', () => {
+    const samples = [
+      'dist/index.html',
+      'dist/model/hyperedges/index.html',
+      'dist/use-cases/index.html',
+    ]
+    for (const path of samples) {
+      const html = readBuilt(path)
+      expect(html, `${path} missing canonical`).toMatch(/<link rel="canonical" href="https:\/\/www\.glossarist\.org[^"]*"/)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Two community-facing improvements building on the use cases section shipped in PR #89.

### Homepage wiring

- Adopters section subheader now links to `/use-cases/` so visitors who land on an adopter card can follow into the story behind it.
- Final CTA adds a "Read Use Cases" button alongside Adoption Guide, Download, and Browse Source.

### SEO: JSON-LD structured data + canonical URLs

`BaseLayout.astro` now emits schema.org JSON-LD on every page:

- **WebSite + SearchAction** on the homepage (eligible for Google sitelinks search box)
- **TechArticle** on all docs / model / reference / use-case pages, with headline, description, inLanguage, publisher Organization, and about-terms

Plus `<link rel="canonical">` on every page — prevents duplicate-content penalties from the trailing-slash ambiguity the Astro config already handles via `trailingSlash: 'ignore'`.

### Test invariants

3 new SEO tests in `test/content-references.test.ts`:
- Homepage emits WebSite JSON-LD with SearchAction
- Docs / model / reference / use-case pages emit TechArticle JSON-LD
- Sample pages carry a canonical URL pointing at `www.glossarist.org`

## Test plan

- [x] `npm run build` passes — 93 pages
- [x] `npm test` passes — 503 tests (was 500)
- [x] No AI attribution in commit
- [ ] Validate JSON-LD in Google Rich Results Test after deploy
- [ ] Confirm canonical URLs render correctly in production

## Built on

PR #89 (use cases + ISO alignment) and PR #88 (hyperedge model alignment).
