### PR TITLE
fix: hyperedge SVGs on light background + correct partitive rake

### DIFF
--- a/public/images/hyperedge-partitive.svg
+++ b/public/images/hyperedge-partitive.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" role="img" aria-labelledby="title desc">
-  <title id="title">Partitive hyperedge — measurement result decomposed into its parts</title>
-  <desc id="desc">A comprehensive concept "measurement result" at the top, with three parts dropping from a shared horizontal backline: measured quantity value (one solid line, compulsory), measurement uncertainty (one solid line, compulsory, delimiting), and measurement procedure (one dashed line, optional). The delimiting part is rendered with a 3x-width bold line per ISO 704:2022.</desc>
+  <title id="title">Partitive hyperedge — VIM measurement result decomposed into its parts</title>
+  <desc id="desc">Comprehensive concept "measurement result" (VIM 2.9) at the top. Three partitive members drop from a shared horizontal backline (complete decomposition). Left tooth: single solid line = compulsory, exactly_one (measured quantity value, VIM 2.10). Middle tooth: double solid line = compulsory, multiple (measurement uncertainties, VIM 2.26 — one or more per result). Right tooth: single dashed line = optional, exactly_one (measurement procedure, VIM 2.6 — sometimes cited alongside the result, sometimes not). Per ISO 704:2022 §5.5.4.3 line notation.</desc>
   <style>
     .box { fill: #f8f9fa; stroke: #343a40; stroke-width: 1.5; }
     .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; fill: #212529; }
@@ -8,7 +8,6 @@
     .backline { stroke: #212529; stroke-width: 2; fill: none; }
     .tooth-solid { stroke: #212529; stroke-width: 1.5; fill: none; }
     .tooth-dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
-    .tooth-delimit { stroke: #212529; stroke-width: 5; fill: none; }
   </style>
 
   <!-- Comprehensive concept -->
@@ -16,24 +15,24 @@
   <text x="360" y="40" text-anchor="middle" class="label" font-weight="600">measurement result</text>
   <text x="360" y="55" text-anchor="middle" class="small">comprehensive · VIM 2.9</text>
 
-  <!-- Backline (close-set = complete) -->
+  <!-- Backline (joined = complete decomposition) -->
   <line x1="120" y1="100" x2="600" y2="100" class="backline"/>
   <text x="60" y="104" class="small">complete</text>
 
-  <!-- Drop lines (the rake teeth) -->
-  <!-- Tooth 1: solid (compulsory, exactly_one) -->
+  <!-- Tooth 1: single solid (compulsory, exactly_one) -->
   <line x1="180" y1="100" x2="180" y2="200" class="tooth-solid"/>
-  <text x="190" y="160" class="small">compulsory</text>
+  <text x="180" y="160" text-anchor="middle" class="small">required · exactly_one</text>
 
-  <!-- Tooth 2: bold 3x (delimiting, compulsory, exactly_one) -->
-  <line x1="360" y1="100" x2="360" y2="200" class="tooth-delimit"/>
-  <text x="372" y="160" class="small" font-weight="600">delimiting</text>
+  <!-- Tooth 2: double solid (compulsory, multiple) -->
+  <line x1="356" y1="100" x2="356" y2="200" class="tooth-solid"/>
+  <line x1="364" y1="100" x2="364" y2="200" class="tooth-solid"/>
+  <text x="360" y="160" text-anchor="middle" class="small">required · multiple</text>
 
-  <!-- Tooth 3: dashed (optional, exactly_one) -->
+  <!-- Tooth 3: single dashed (optional, exactly_one) -->
   <line x1="540" y1="100" x2="540" y2="200" class="tooth-dashed"/>
-  <text x="490" y="160" class="small">optional</text>
+  <text x="540" y="160" text-anchor="middle" class="small">optional · exactly_one</text>
 
-  <!-- Partitive concept boxes -->
+  <!-- Partitive member boxes -->
   <rect x="100" y="220" width="160" height="40" rx="6" class="box"/>
   <text x="180" y="238" text-anchor="middle" class="label">measured quantity value</text>
   <text x="180" y="252" text-anchor="middle" class="small">VIM 2.10</text>
@@ -47,6 +46,7 @@
   <text x="540" y="252" text-anchor="middle" class="small">VIM 2.6</text>
 
   <!-- Footer legend -->
-  <text x="360" y="310" text-anchor="middle" class="small">ISO 704:2022 §5.5.4.3 — line notation: solid = required, dashed = optional, bold 3x = delimiting</text>
-  <text x="360" y="326" text-anchor="middle" class="small">All teeth share the comprehensive AND the criterion of subdivision (coordinate concepts, ISO 12620)</text>
+  <text x="360" y="310" text-anchor="middle" class="small">ISO 704:2022 §5.5.4.3 — line notation: single solid = required + exactly_one,</text>
+  <text x="360" y="326" text-anchor="middle" class="small">double solid = required + multiple, dashed = optional. All teeth share the comprehensive</text>
+  <text x="360" y="342" text-anchor="middle" class="small">AND the criterion of subdivision (coordinate concepts per ISO 12620).</text>
 </svg>

--- a/src/content/blog/2026-07-30-hyperedges-per-file-storage.mdx
+++ b/src/content/blog/2026-07-30-hyperedges-per-file-storage.mdx
@@ -32,8 +32,10 @@ partial (continues off-page).
 
 Here's a PartitiveHyperedge — the VIM *measurement result* (2.9) rake:
 
-![Partitive hyperedge diagram showing measurement result with three parts](/images/hyperedge-partitive.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-partitive.svg" alt="Partitive hyperedge diagram showing measurement result with three parts" loading="lazy" />
+  <figcaption>Partitive hyperedge — VIM measurement result rake showing three MECE member dimensions.</figcaption>
+</figure>
 Three teeth drop from a joined backline: one solid (required part), one
 bold 3x (required + delimiting — distinguishes from coordinate concepts),
 and one dashed (optional). All three share the comprehensive AND the
@@ -55,8 +57,10 @@ rakes on the same genus.
 
 Here's how that looks in source diagrams:
 
-![Generalization hyperedge with two criterion groups on measurement standard](/images/hyperedge-generalization.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-generalization.svg" alt="Generalization hyperedge with two criterion groups on measurement standard" loading="lazy" />
+  <figcaption>Generalization hyperedge — OIML measurement standard with two criterion groups (multidimensionality).</figcaption>
+</figure>
 Binary `broader_generic` edges can't express this grouping coherently. You'd
 have six flat lists of narrower edges with no way to distinguish which
 species belong to which decomposition. GenericHyperedge groups species by
@@ -132,8 +136,10 @@ That worked when the array was small. With OIML-scale data it breaks:
 
 ### The new layout
 
-![Per-file storage layout with directory tree and YAML preview](/images/hyperedge-per-file-storage.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-per-file-storage.svg" alt="Per-file storage layout with directory tree and YAML preview" loading="lazy" />
+  <figcaption>Per-file storage layout — concept files alongside relation files under <code>relations/&lt;id&gt;/</code>.</figcaption>
+</figure>
 Each file holds exactly one hyperedge (one comprehensive + one criterion
 + its members). The directory IS the index — `relations/5-1/` enumerates
 every decomposition of concept 5.1.
@@ -167,8 +173,10 @@ ISO 704:2022 encodes per-member multiplicity via two orthogonal diagram
 line dimensions. Glossarist decomposes this into a **MECE pair**: presence
 (solid vs dashed) × count (line count).
 
-![MECE member multiplicity table showing all 5 valid combinations plus the invalid combo](/images/hyperedge-mece-multiplicity.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-mece-multiplicity.svg" alt="MECE member multiplicity table showing all 5 valid combinations plus the invalid combo" loading="lazy" />
+  <figcaption>MECE member multiplicity — all five valid presence × count combinations plus the invalid one.</figcaption>
+</figure>
 Five valid combinations, one invalid. The invalid `(optional, at_least_one)`
 combo is rejected: an optional part has vacuous at-least-one (it may not
 exist at all), so it collapses to `(optional, multiple)`. Both the JSON

--- a/src/content/model/generic-relations.mdx
+++ b/src/content/model/generic-relations.mdx
@@ -26,8 +26,10 @@ ISO 704:2022 §5.5.4.2.1 works through *computer mouse* in detail. The genus is 
 
 Each rake is its own `GenericHyperedge` (its own file under `relations/<genus-id>/`):
 
-![Generic hyperedge — computer mouse with two criteria of subdivision (ISO 704:2022 §5.5.4.2.1)](/images/hyperedge-generic-computer-mouse.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-generic-computer-mouse.svg" alt="Generic hyperedge — computer mouse with two criteria of subdivision (ISO 704:2022 §5.5.4.2.1)" loading="lazy" />
+  <figcaption>Generic hyperedge — ISO 704:2022 §5.5.4.2.1 canonical computer-mouse example with two criterion rakes.</figcaption>
+</figure>
 Species **within one rake** are coordinate concepts (share genus + share criterion). Species **across rakes** are NOT coordinate — *optical mouse* (criterion: movement detection) and *wireless mouse* (criterion: connection) share the genus but no criterion, so they don't belong to the same coordinate set.
 
 ### Per-species delimiting characteristic (ISO 704:2022 §5.5.4.2.1)
@@ -64,8 +66,10 @@ The *computer mouse* example has 2 criteria. Real terminology vocabularies go fu
 
 Each criterion group is a distinct `GenericHyperedge`. Without the hyperedge shape, these decompositions collapse into an undifferentiated list of binary `narrower_generic` edges with no way to say which species belong to which rake.
 
-![Generalization hyperedge — measurement standard with two criterion groups](/images/hyperedge-generalization.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-generalization.svg" alt="Generalization hyperedge — measurement standard with two criterion groups" loading="lazy" />
+  <figcaption>Generalization hyperedge — OIML measurement standard with two criterion groups (multidimensionality).</figcaption>
+</figure>
 ## YAML authoring
 
 Per-file layout: `relations/<comprehensive-id>/<criterion-slug>.yaml` (see [Hyperedges — Per-file storage](/model/hyperedges#per-file-storage) for the rationale).

--- a/src/content/model/hyperedges.mdx
+++ b/src/content/model/hyperedges.mdx
@@ -24,8 +24,10 @@ A hyperedge is drawn as a **rake**: a horizontal backline connects the comprehen
 
 The VIM *measurement result* (2.9) decomposes into three parts. The diagram encodes multiplicity per part:
 
-![Partitive hyperedge diagram](/images/hyperedge-partitive.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-partitive.svg" alt="Partitive hyperedge diagram" loading="lazy" />
+  <figcaption>Partitive hyperedge — VIM measurement result rake showing three MECE member dimensions.</figcaption>
+</figure>
 - **Solid line** = required (must exist in every instance)
 - **Dashed line** = optional (exists in some instances only)
 - **Bold 3x-width line** = delimiting (distinguishes the comprehensive from coordinate concepts)
@@ -35,38 +37,48 @@ The VIM *measurement result* (2.9) decomposes into three parts. The diagram enco
 
 The OIML *measurement standard* (5.1) decomposes by **multiple criteria**. Each criterion is a distinct hyperedge on the same genus, and each species carries its delimiting characteristic in a side rectangle per ISO 704:2022 §5.5.4.2.1:
 
-![Generalization hyperedge with two criterion groups and delimiting characteristics](/images/hyperedge-generalization.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-generalization.svg" alt="Generalization hyperedge with two criterion groups and delimiting characteristics" loading="lazy" />
+  <figcaption>Generalization hyperedge — OIML measurement standard with two criterion groups (multidimensionality).</figcaption>
+</figure>
 Two hyperedges, same comprehensive, different criteria. Species within one rake are coordinate concepts (share genus + share criterion). Species across rakes are NOT coordinate — they belong to different decompositions.
 
 ### The canonical ISO 704:2022 §5.5.4.2.1 example — computer mouse (generic)
 
 ISO 704:2022 §5.5.4.2.1 uses *computer mouse* as its canonical worked example for **generic relations**. The same genus is decomposed by two distinct criteria of subdivision (multidimensionality, §5.6.3): by means of movement detection (mechanical / optomechanical / optical) and by computer connection (wired / wireless). Each species carries a delimiting characteristic:
 
-![Computer mouse — ISO 704:2022 §5.5.4.2.1 canonical generic example with multidimensionality](/images/hyperedge-computer-mouse.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-computer-mouse.svg" alt="Computer mouse — ISO 704:2022 §5.5.4.2.1 canonical generic example with multidimensionality" loading="lazy" />
+  <figcaption>Generic hyperedge — ISO 704:2022 §5.5.4.2.1 canonical computer-mouse example.</figcaption>
+</figure>
 The thicker blue and brown backlines distinguish the two criteria. The characteristic rectangles carry the intension-difference that makes each species distinct within its rake.
 
 ### The canonical ISO 704:2022 §5.5.4.2.2 example — optomechanical mouse (partitive)
 
 Distinct from §5.5.4.2.1 above. The optomechanical mouse is also used as the canonical **partitive** example — its parts (mouse ball, rollers, infrared emitter/sensor, etc.) are modeled as a PartitiveHyperedge. The five delimiting parts distinguish it from coordinate concepts (*mechanical mouse*, *optical mouse*):
 
-![Optomechanical mouse — ISO 704:2022 §5.5.4.2.2 canonical partitive example](/images/hyperedge-optomechanical-mouse.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-optomechanical-mouse.svg" alt="Optomechanical mouse — ISO 704:2022 §5.5.4.2.2 canonical partitive example" loading="lazy" />
+  <figcaption>Partitive hyperedge — ISO 704:2022 §5.5.4.2.2 canonical optomechanical-mouse example with delimiting parts.</figcaption>
+</figure>
 ### Fictitious example — bicycle (partitive)
 
 A *bicycle* decomposed by physical structure, exercising every MECE dimension:
 
-![Bicycle partitive hyperedge — fictitious example](/images/hyperedge-bicycle.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-bicycle.svg" alt="Bicycle partitive hyperedge — fictitious example" loading="lazy" />
+  <figcaption>Partitive hyperedge — fictitious bicycle example exercising every MECE dimension.</figcaption>
+</figure>
 Bold lines = delimiting (frame, wheel, handlebar distinguish bicycle from unicycle/tricycle/scooter/motorcycle). Double solid lines = `count: multiple` (typically 2 wheels, 2 pedals, 2 brakes). Dashed = `presence: optional` (bell, light). Some optional parts combine both — `optional + multiple` (light: 0, 1, or 2+).
 
 ### Fictitious example — vehicle (generic)
 
 A *vehicle* genus with **two distinct criterion groups** — by motive power and by terrain:
 
-![Vehicle generic hyperedge — fictitious example with two criterion groups](/images/hyperedge-vehicle.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-vehicle.svg" alt="Vehicle generic hyperedge — fictitious example with two criterion groups" loading="lazy" />
+  <figcaption>Generic hyperedge — fictitious vehicle example with two criterion groups.</figcaption>
+</figure>
 Each rake is a distinct hyperedge (distinct file under `relations/example-vehicle/`). Species within one rake are coordinate (bicycle and car share "vehicle" + "by motive power"); species across rakes are not (bicycle and boat share the genus but not a criterion).
 
 ## How they work
@@ -80,8 +92,10 @@ ISO 704:2022 encodes per-member multiplicity via diagram line notation. Glossari
 
 The bold 3x-width line in ISO 704 diagrams is **not** a third MECE axis — it's modeled differently per leaf (`is_delimiting: boolean` on `PartitiveMember` for delimiting parts, `delimitingCharacteristic: LocalizedString` on `GenericMember` for the species intension-difference). See [Model](#model) below.
 
-![MECE member multiplicity table](/images/hyperedge-mece-multiplicity.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-mece-multiplicity.svg" alt="MECE member multiplicity table" loading="lazy" />
+  <figcaption>MECE member multiplicity — all five valid presence × count combinations plus the invalid one.</figcaption>
+</figure>
 Six combinations mathematically possible; five valid. The invalid one (`optional + at_least_one`) collapses to `optional + multiple` because an optional part has vacuous at-least-one. Both the JSON Schema and the Ruby/JS validators reject it with a clear error message.
 
 ### Coordinate-concept coherence (ISO 12620)
@@ -115,8 +129,10 @@ relations/<comprehensive-id>/<criterion-slug>.yaml
 
 The concept file no longer carries hyperedges inline. The directory IS the index — `relations/viml-5-1/` enumerates every decomposition of concept 5.1.
 
-![Per-file storage layout](/images/hyperedge-per-file-storage.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-per-file-storage.svg" alt="Per-file storage layout" loading="lazy" />
+  <figcaption>Per-file storage layout — concept files alongside relation files under <code>relations/&lt;id&gt;/</code>.</figcaption>
+</figure>
 Reasons for the move:
 
 - **i18n bloat** — a comprehensive with 6 hyperedges × 3 languages × (criterion + notes + sources' modification) is ~60+ localized strings piled into the concept file

--- a/src/content/model/partitive-relations.mdx
+++ b/src/content/model/partitive-relations.mdx
@@ -39,8 +39,10 @@ Delimiting is **orthogonal** to presence and count — a delimiting part can be 
 | mouse button | no | all computer mice have buttons |
 | mouse wheel | no | not found on all optomechanical mice (optional) |
 
-![Optomechanical mouse — ISO 704:2022 canonical partitive example](/images/hyperedge-optomechanical-mouse.svg)
-
+<figure class="g-figure-light">
+  <img src="/images/hyperedge-optomechanical-mouse.svg" alt="Optomechanical mouse — ISO 704:2022 canonical partitive example" loading="lazy" />
+  <figcaption>Partitive hyperedge — ISO 704:2022 §5.5.4.2.2 canonical optomechanical-mouse example with delimiting parts.</figcaption>
+</figure>
 ## YAML authoring
 
 Per-file layout: `relations/<comprehensive-id>/<criterion-slug>.yaml` (see [Hyperedges — Per-file storage](/model/hyperedges#per-file-storage) for the rationale).

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -187,6 +187,18 @@
     padding: 1rem;
     background: var(--g-bg-soft);
   }
+  /* SVGs authored with light-mode palette (hyperedge diagrams, etc.)
+     must always render on a light card — otherwise their hardcoded
+     dark-on-light colors become unreadable in dark mode. */
+  figure.g-figure-light img,
+  .g-figure-light img {
+    background: #ffffff !important;
+    border-color: #dee2e6 !important;
+    padding: 1.5rem !important;
+  }
+  .g-figure-light figcaption {
+    color: var(--g-text-2);
+  }
   figcaption {
     margin-top: 0.75rem;
     font-size: 0.875rem;

--- a/test/content-references.test.ts
+++ b/test/content-references.test.ts
@@ -319,3 +319,51 @@ describe('SEO invariants (JSON-LD + canonical)', () => {
   })
 })
 
+describe('Hyperedge SVG rendering invariants', () => {
+  // SVGs authored with a light-mode palette (dark text/strokes on light
+  // box fills) must be wrapped in <figure class="g-figure-light"> so
+  // they render on a forced-light card in dark mode. Otherwise they're
+  // unreadable. Also: the partitive SVG must not mark "measurement
+  // uncertainty" as a delimiting part (it isn't — every measurement
+  // result has measurement uncertainty; nothing is distinguished).
+
+  it('every hyperedge SVG reference is wrapped in g-figure-light', () => {
+    const files = [
+      'src/content/model/hyperedges.mdx',
+      'src/content/model/generic-relations.mdx',
+      'src/content/model/partitive-relations.mdx',
+      'src/content/blog/2026-07-30-hyperedges-per-file-storage.mdx',
+    ]
+    for (const rel of files) {
+      const src = readFileSync(join(root, rel), 'utf-8')
+      // Any line referencing a hyperedge SVG must be inside a figure.g-figure-light block.
+      // Find each SVG reference and check the surrounding block.
+      const lines = src.split('\n')
+      let inLightFigure = false
+      const offenders: string[] = []
+      for (const line of lines) {
+        if (/^<figure class="g-figure-light">/.test(line.trim())) inLightFigure = true
+        if (/^<\/figure>/.test(line.trim())) inLightFigure = false
+        if (/\/images\/hyperedge-[a-z-]+\.svg/.test(line) && !inLightFigure) {
+          offenders.push(line.trim())
+        }
+      }
+      expect(offenders, `${rel}: hyperedge SVGs outside g-figure-light wrapper:\n${offenders.join('\n')}`).toEqual([])
+    }
+  })
+
+  it('hyperedge-partitive.svg does NOT mark measurement uncertainty as delimiting', () => {
+    // Earlier version of this SVG incorrectly labeled "measurement
+    // uncertainty" as a delimiting part. Per VIM, measurement uncertainty
+    // is part of EVERY measurement result — it doesn't distinguish
+    // coordinate concepts, so it isn't delimiting.
+    const svg = readFileSync(join(root, 'public/images/hyperedge-partitive.svg'), 'utf-8')
+    expect(svg).not.toMatch(/delimiting/i)
+    expect(svg).not.toMatch(/tooth-delimit/)
+    // The corrected SVG must show three distinct MECE multiplicities
+    expect(svg).toMatch(/required · exactly_one/)
+    expect(svg).toMatch(/required · multiple/)
+    expect(svg).toMatch(/optional · exactly_one/)
+  })
+})
+


### PR DESCRIPTION
## Summary

Two SVG issues flagged earlier are now fixed.

### Wrongly-drawn: hyperedge-partitive.svg

The previous version marked **measurement uncertainty** as a delimiting part (bold 3x-width line per ISO 704:2022 §5.5.4.2.2). That's incorrect — measurement uncertainty is part of *every* measurement result; it doesn't distinguish coordinate concepts, so it isn't delimiting. Delimiting applies when a part separates the comprehensive from coordinate concepts (e.g. *mouse-ball* distinguishes *optomechanical mouse* from *optical mouse* — see the canonical §5.5.4.2.2 example).

Redesigned to demonstrate three distinct MECE member multiplicities on one rake — more educational than the misleading delimiting markup:

| Part | Multiplicity | Notation |
|------|--------------|----------|
| measured quantity value | required · exactly_one | single solid |
| measurement uncertainty | required · multiple | double solid |
| measurement procedure | optional · exactly_one | single dashed |

### Light background for all hyperedge SVGs

These SVGs were authored with a light-mode palette (dark text/strokes on `#f8f9fa` box fills). In dark mode they became unreadable. Solution: a new `.g-figure-light` class in `base.css` forces a light card around the SVG regardless of page theme.

15 hyperedge SVG references across 4 MDX files converted from markdown image syntax to `<figure class="g-figure-light">` blocks with descriptive `<figcaption>`.

### Test invariants

Two new tests in `test/content-references.test.ts`:

1. Every hyperedge SVG reference must be wrapped in `<figure class="g-figure-light">` — catches any future addition that skips the wrapper.
2. `hyperedge-partitive.svg` must not contain the words "delimiting" / "tooth-delimit" (catches regression of the wrongly-drawn markup), and must contain all three corrected multiplicity labels.

## Test plan

- [x] `npm run build` passes — 93 pages
- [x] `npm test` passes — 505 tests (was 503)
- [x] No AI attribution in commit
- [ ] Visual sanity check in light + dark mode after deploy
