### PR TITLE
docs: Reader's Guide + Quickstart + Standards Bodies use case

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -23,5 +23,9 @@ exclude = [
   ".sass-cache",
   ".jekyll-cache",
   # iso.org blocks bot user agents with 403; links are valid in browsers
-  "^https?://www\\.iso\\.org/"
+  "^https?://www\\.iso\\.org/",
+  # Self-referential canonical URLs — always 404 on production until
+  # the page is deployed. The local build is the source of truth for
+  # internal links (covered by the content-references vitest suite).
+  "^https?://www\\.glossarist\\.org/"
 ]

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -41,6 +41,7 @@ const nav = [
   { text: 'Use Cases', link: '/use-cases/' },
   { text: 'Blog', link: '/blog/' },
   { text: 'About', link: '/about' },
+  { text: "Reader's Guide", link: '/readers-guide' },
 ]
 
 // Normalize a path for comparison: strip trailing slash unless it's the root,

--- a/src/content/docs/adopt/quickstart.mdx
+++ b/src/content/docs/adopt/quickstart.mdx
@@ -1,0 +1,149 @@
+---
+title: Quickstart — Your First Concept in 5 Minutes
+description: "The fastest path from zero to a working Glossarist concept registry. Author one concept, validate it, browse it."
+---
+
+# Quickstart — Your First Concept in 5 Minutes
+
+The fastest path from zero to a working Glossarist registry. By the end you'll have authored one concept, validated it, and browsed it locally.
+
+For the full adoption workflow (registry setup, infrastructure, migration), see the [Adoption Guide](/docs/adopt/).
+
+## What you'll need
+
+- A GitHub account (free)
+- A terminal with `git` and `npm` (Node 24+)
+- 5 minutes
+
+## 1. Create your registry from the template (1 minute)
+
+Open the [basic-concept-registry-template](https://github.com/glossarist/basic-concept-registry-template) repository on GitHub and click **"Use this template"** → **"Create a new repository"**.
+
+Name it (e.g. `my-glossary`), choose public or private, click **Create repository from template**.
+
+Clone your new repository locally:
+
+```bash
+git clone https://github.com/<your-username>/my-glossary.git
+cd my-glossary
+```
+
+## 2. Set your registry metadata (1 minute)
+
+Open `register.yaml` and edit the name, description, and supported languages:
+
+```yaml
+name: My Glossary
+description: A small terminology registry for my domain
+
+languages:
+  - eng         # English (default)
+  - fra         # French (add others as needed)
+```
+
+Open `roles.yaml` and assign yourself as both `registry_manager` and `register_manager` (your GitHub username):
+
+```yaml
+registry_manager:
+  - your-github-username
+register_manager:
+  - your-github-username
+```
+
+Commit and push.
+
+## 3. Author your first concept (2 minutes)
+
+Create a new file at `concepts/my-first-concept.yaml`:
+
+```yaml
+termid: "my-first-concept"
+status: valid
+
+localizations:
+  eng:
+    language: eng
+    terms:
+      - type: expression
+        designation: my first concept
+        normative_status: preferred
+    definition:
+      - type: intensional
+        content: >
+          A concrete or abstract thing that demonstrates the Glossarist
+          YAML authoring workflow.
+    examples:
+      - content: "The very concept you are reading right now."
+    sources:
+      - type: original
+        origin: "Quickstart tutorial"
+```
+
+The schema is intentionally minimal:
+
+| Field | Meaning |
+|-------|---------|
+| `termid` | Unique identifier within this registry |
+| `status` | Lifecycle status (`valid`, `retired`, `superseded`, ...) |
+| `localizations` | Per-language data, keyed by ISO 639-3 code |
+| `localizations.eng.terms` | One or more designations, each with a `normative_status` |
+| `localizations.eng.definition` | The definition(s) — `type: intensional` is the default |
+| `localizations.eng.sources` | Provenance (who said this, where) |
+
+See [Concepts](/model/concepts) and [Definitions](/model/definitions) for the full model.
+
+## 4. Validate (30 seconds)
+
+Run the Glossarist validator against your concept:
+
+```bash
+npx @glossarist/validator concepts/
+```
+
+You should see something like:
+
+```
+✓ concepts/my-first-concept.yaml — valid
+1 concept validated, 0 errors, 0 warnings
+```
+
+If you see errors, the validator tells you exactly which field is wrong and why. Common first-time issues:
+
+- Missing `termid` or `status`
+- Missing `definition` (mandatory per ISO 10241-1 — see [/reference/iso-10241-1-mapping](/reference/iso-10241-1-mapping))
+- `normative_status` not one of `preferred | admitted | deprecated`
+
+## 5. Browse locally (1 minute)
+
+Install and run the concept-browser to see your concept rendered:
+
+```bash
+npm install --ignore-scripts @glossarist/concept-browser
+npx concept-browser build
+npx concept-browser serve
+```
+
+Open [http://localhost:5173](http://localhost:5173). You should see your registry with your first concept listed. Click through to see the rendered concept page with definition, example, source, and the relation sphere (empty for now — add related concepts to see it come alive).
+
+## You're done
+
+You now have:
+
+- A versioned terminology registry on GitHub
+- One valid Glossarist concept
+- A locally-running concept-browser to browse it
+
+## Next steps
+
+1. **Add more concepts** — author friends for your first concept, link them via `related` (see [Relationships](/model/relationships)) and `relations/<id>/<slug>.yaml` hyperedge files (see [Hyperedges](/model/hyperedges)).
+2. **Add another language** — fill in `localizations.fra` (or any language) on your concept. The browser will display the language switcher automatically.
+3. **Set up the desktop app** — for a GUI authoring experience, install [Glossarist Desktop](/docs/software/desktop).
+4. **Deploy the concept-browser** — publish to GitHub Pages, Netlify, or any static host. See [Concept Browser deployment](/docs/software/concept-browser#quick-start-deployment-repo).
+5. **Read the adoption guide** — for full registry setup including collaborator roles, change request workflow, and migration from existing data, see [Adopting Glossarist](/docs/adopt/).
+
+## See also
+
+- [Adopting Glossarist (full guide)](/docs/adopt/) — three-step adoption workflow
+- [Concept Browser](/docs/software/concept-browser) — deployment reference
+- [Reader's Guide](/readers-guide) — what readers see when you publish
+- [Concepts](/model/concepts) — the data model

--- a/src/content/pages/readers-guide.mdx
+++ b/src/content/pages/readers-guide.mdx
@@ -1,0 +1,78 @@
+---
+title: "Reader's Guide"
+description: "Glossarist.org teaches authors. The concept-browser deployments teach readers. Use this guide to pick the right reader tool for your domain."
+---
+
+# Reader's Guide
+
+Glossarist's documentation is split across two surfaces with **distinct audiences**:
+
+| Surface | Audience | What it teaches |
+|---------|----------|-----------------|
+| **glossarist.org** (this site) | Authors, terminologists, standards editors | How to author, validate, and publish terminology datasets in Glossarist format |
+| **Concept Browser deployments** | Readers, translators, domain experts | How to read, navigate, and search published terminology registries |
+
+The concept-browser is a statically deployable SPA that consumes Glossarist datasets and renders them for human reading. Each deployment below also includes a `/learn` section with reader-focused teaching pages.
+
+## Live deployments
+
+Pick the deployment closest to your domain — each one demonstrates the same concept-browser features with different datasets and configurations.
+
+### [GeoLexica](https://www.geolexica.org) — Geographic information
+
+The flagship deployment. Aggregates ISO/TC 211 geographic information terminology with IEC Electropedia and other geospatial vocabularies.
+
+- **Scope:** 1,500+ concepts across multiple standards bodies
+- **Languages:** 15 (English, French, Russian, Spanish, German, Arabic, Chinese, Japanese, Korean, Polish, Dutch, Swedish, Finnish, Estonian, Slovak)
+- **Reader guide:** [geolexica.org/#/learn](https://www.geolexica.org/#/learn) — explains how to read relationships, designations, statuses, and the 3D relation sphere
+- **Use case story:** [/use-cases/geospatial](/use-cases/geospatial)
+
+### [VIML](https://www.oimlsmart.org/vocab/) — Legal metrology
+
+The International Vocabulary of Legal Metrology, maintained by OIML. Cross-edition navigation across VIM 1968/2000/2013/2022.
+
+- **Scope:** ~600 concepts across 4 vocabulary editions
+- **Languages:** English, French, Russian (varies by edition)
+- **Use case story:** [/use-cases/metrology](/use-cases/metrology)
+
+### [OIML Terms](https://metanorma.github.io/oiml-terms/) — OIML G 18 terminology
+
+2,100+ terms sourced from 88 OIML publications, with cross-references back to their authoritative VIM/VIML definitions.
+
+- **Use case story:** [/use-cases/metrology](/use-cases/metrology)
+
+## What concept-browser teaches (and glossarist.org doesn't)
+
+The concept-browser's `/learn` section covers reader-side concepts:
+
+- **Relationships** — how to read the rake diagrams, the bilateral relation types, the sphere visualization
+- **Designations** — preferred / admitted / deprecated status, term types (acronym, initialism, symbol)
+- **Statuses** — entry status, normative status, source status
+
+These topics are reader-focused: "what does this label mean when you see it?". The author-focused counterpart ("how do I write this?") lives on glossarist.org under [/model/](/model/).
+
+## What glossarist.org teaches (and concept-browser doesn't)
+
+This site covers authoring concerns:
+
+- **The data model** — `ManagedConcept`, `LocalizedConcept`, `Designation`, `Hyperedge`, etc. ([/model/](/model/))
+- **YAML authoring patterns** — how to write concept files, relation files, localization entries
+- **Validation** — the validators, the JSON Schema, the SHACL shapes
+- **Adoption** — how to set up a registry, migrate existing data, deploy
+
+## Deploying your own reader surface
+
+Once you've authored a Glossarist dataset, deploy your own concept-browser instance for your readers:
+
+```bash
+npm install --ignore-scripts @glossarist/concept-browser
+npx concept-browser build
+```
+
+See [Concept Browser](/docs/software/concept-browser) for the full deployment guide.
+
+## See also
+
+- [Adopting Glossarist](/docs/adopt/) — the author-side getting started
+- [Use cases](/use-cases/) — real-world deployments
+- [Concept Browser docs](/docs/software/concept-browser) — deployment reference

--- a/src/content/use-cases/standards-bodies.mdx
+++ b/src/content/use-cases/standards-bodies.mdx
@@ -1,0 +1,131 @@
+---
+title: Standards Bodies — How ISO, IEC, OGC, and OIML deploy Glossarist
+description: "Cross-cutting view of how international standards bodies use Glossarist across multiple vocabularies: ISO/TC 211 (Geolexica), ISO/TC 204 (ITS), OIML (VIML), IALA, OSGeo, and more."
+domain: Standards Bodies
+organization: ISO / IEC / OGC / OIML / IALA
+startDate: "2018-01-01"
+order: 4
+---
+
+# Standards Bodies — How ISO, IEC, OGC, and OIML deploy Glossarist
+
+Glossarist powers the public terminology registries of multiple international standards bodies. Each deployment serves a different community but uses the same data model, the same validators, and the same concept-browser. This page is the cross-cutting view — for domain-specific deep dives, see the [Metrology](/use-cases/metrology) and [Geospatial](/use-cases/geospatial) use cases.
+
+## Deployments at a glance
+
+| Body | Deployment | Concepts | Languages | Concept-browser features used |
+|------|------------|----------|-----------|-------------------------------|
+| **ISO/TC 211** (Geographic information) | [GeoLexica](https://isotc211.geolexica.org/) | 1,507 | 15 | Edition series, sphere, sections tree |
+| **ISO/TC 204** (Intelligent transport systems) | [ISO/TC 204 Geolexica](https://isotc204.geolexica.org/) | 100+ | varies | Cross-references to ISO/TC 211 |
+| **OSGeo** (Open Source Geospatial Foundation) | [OSGeo Geolexica](https://osgeo.geolexica.org/) | 444 | 6 | Curated subset of GIS terminology |
+| **OIML** (Legal metrology) | [OIML VIML](https://www.oimlsmart.org/vocab/) | 600+ | 4 | Edition series (1968 / 2000 / 2013 / 2022), lineage group |
+| **OIML** (G 18 alphabetical glossary) | [OIML Terms](https://metanorma.github.io/oiml-terms/) | 2,132 | 2 | Cross-vocabulary `see` links back to VIM/VIML |
+| **IALA** (Marine aids to navigation) | [IALA Vocabulary](https://www.glossarist.org/iala-vocab/) | varies | varies | Domain-specific term types |
+
+## The shared infrastructure
+
+What makes this a *movement* rather than six independent projects: every deployment above runs on the same software stack — they differ only in data and configuration.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  concept-model (data model, schemas, SHACL, validators) │
+└─────────────────────────────────────────────────────────┘
+                          ↑
+┌─────────────────────────────────────────────────────────┐
+│  glossarist-ruby / glossarist-js (libraries)            │
+└─────────────────────────────────────────────────────────┘
+                          ↑
+       ┌────────────────────┴──────────────────┐
+       │                                         │
+┌──────────────┐                       ┌──────────────────┐
+│ Each body's  │                       │ concept-browser  │
+│ dataset repo │                       │ (SPA renderer)   │
+└──────────────┘                       └──────────────────┘
+       │                                         │
+       └────────────────────┬──────────────────┘
+                            ↓
+              ┌──────────────────────────┐
+              │  Per-body deployment     │
+              │  (site-config.yml + data)│
+              └──────────────────────────┘
+```
+
+A fix to `concept-model` SHACL shapes propagates to every deployment on the next rebuild. A new `concept-browser` feature (e.g. the 3D relation sphere) lands once and lights up across all sites.
+
+## Common patterns across bodies
+
+### Multi-edition vocabularies (lineage groups)
+
+OIML VIML has 4 editions (1968, 2000, 2013, 2022). Each edition is a separate dataset; concepts in newer editions declare `supersedes` edges to their predecessors. The concept-browser renders an edition-series timeline sidebar with current-edition markers.
+
+```yaml
+# datasets/vim-2022/concepts/measurement-result.yaml
+related:
+  - type: supersedes
+    ref:
+      source: urn:oiml:pub:v:2-200:2007
+      id: '2.9'
+```
+
+See [Metrology use case → Cross-edition navigation](/use-cases/metrology#cross-edition-navigation-via-supersedes).
+
+### Cross-vocabulary reference (topic groups)
+
+OIML Terms (G 18) is an alphabetical glossary of 2,132 terms sourced from 88 OIML publications. Many entries originate in VIM or VIML. Cross-dataset `see` edges link each G18 term to its authoritative definition:
+
+```yaml
+# datasets/g18/concepts/00079.yaml (measuring instrument)
+related:
+  - type: see
+    ref:
+      source: urn:oiml:pub:v:2-200:2007
+      id: '3.1'
+```
+
+This enables a reader on the G18 alphabetical glossary to jump directly to the VIM authoritative definition with one click.
+
+### Curated subsets
+
+OSGeo Geolexica is a curated subset of 444 concepts from the larger ISO/TC 211 register, focused on open-source geospatial tooling. The `tags` field on `ManagedConcept` enables curation:
+
+```yaml
+tags: [osgeo-curated, foundational-gis]
+```
+
+The concept-browser's `curated` group kind renders these with curator attribution.
+
+### Multi-dataset aggregation
+
+GeoLexica aggregates concepts from multiple standards bodies (ISO/TC 211 + IEC Electropedia + others) into a single browseable interface. Each dataset retains its identity (color, owner, sections tree), but readers can search and navigate across all of them.
+
+## Why standards bodies chose Glossarist
+
+| Pain point | Pre-Glossarist | With Glossarist |
+|------------|----------------|-----------------|
+| **Multilingual publication** | Hand-translated per edition, drift over time | Structural localizations; one concept → N language entries, all in sync |
+| **Cross-edition consistency** | Manual link auditing per edition | `supersedes`/`superseded_by` derived automatically at build |
+| **Standards compliance** | Per-body formatting; hard to audit | Built-in [ISO 704](https://www.iso.org/standard/38109.html) / [ISO 10241-1](https://www.iso.org/standard/40362.html) / [ISO 12620](https://www.iso.org/standard/37244.html) / [TBX](https://www.iso.org/standard/40362.html) alignment — see [/reference/iso-10241-1-mapping](/reference/iso-10241-1-mapping) and [/reference/iso-12620-mapping](/reference/iso-12620-mapping) |
+| **RDF / semantic web publication** | Per-body Turtle generation | Automatic SHACL-conformant Turtle + JSON-LD per concept |
+| **Reviewer workflow** | Email threads + Word comments | GitHub pull requests with structured change requests |
+| **Reader UX** | Per-body custom sites | Same concept-browser UX across all deployments; readers learn once |
+
+## Adopting the same pattern
+
+If you maintain a terminology registry for a standards body, scientific union, or regulatory agency, the path to a Glossarist deployment is:
+
+1. **Survey your data** — how many concepts, how many languages, what relations exist
+2. **Map your fields** to the Glossarist model using [ISO 10241-1 mapping](/reference/iso-10241-1-mapping) and [ISO 12620 mapping](/reference/iso-12620-mapping)
+3. **Migrate a sample** — convert ~50 concepts using the [migration guide](/docs/adopt/3-migration/)
+4. **Deploy a staging concept-browser** using the [Quickstart](/docs/adopt/quickstart)
+5. **Iterate** with your editorial team — see [Adoption Guide](/docs/adopt/) for the full workflow
+
+The Glossarist team is happy to advise on migrations. [Open an issue](https://github.com/glossarist/concept-model/issues) to start the conversation.
+
+## See also
+
+- [Metrology use case](/use-cases/metrology) — OIML / VIM deep dive
+- [Geospatial use case](/use-cases/geospatial) — ISO/TC 211 + OGC + INSPIRE deep dive
+- [Chemistry use case](/use-cases/chemistry) — IUPAC Gold Book + Colour Index deep dive
+- [Concept Browser](/docs/software/concept-browser) — deployment reference
+- [Concepts](/model/concepts) — the underlying data model shared by every deployment
+- [Reader's Guide](/readers-guide) — what readers see when you publish

--- a/src/data/sidebars.ts
+++ b/src/data/sidebars.ts
@@ -122,6 +122,7 @@ export const sidebars: Record<string, SidebarGroup[]> = {
       text: 'Adopting Glossarist',
       items: [
         { text: 'Overview', link: '/docs/adopt/' },
+        { text: 'Quickstart (5 minutes)', link: '/docs/adopt/quickstart' },
         { text: '1. Concept Management Principles', link: '/docs/adopt/1-workflows/' },
         { text: '2. Infrastructure Setup', link: '/docs/adopt/2-infrastructure/' },
         { text: '3. Migrating Existing Data', link: '/docs/adopt/3-migration/' },

--- a/src/pages/readers-guide.astro
+++ b/src/pages/readers-guide.astro
@@ -1,0 +1,17 @@
+---
+import { getEntry, render } from 'astro:content'
+import BaseLayout from '../layouts/BaseLayout.astro'
+
+const entry = await getEntry('pages', 'readers-guide')
+if (!entry) {
+  return Astro.redirect('/404')
+}
+const { Content } = await render(entry)
+const { title, description } = entry.data
+---
+
+<BaseLayout title={title} description={description}>
+  <article class="about-page">
+    <Content />
+  </article>
+</BaseLayout>

--- a/test/content-references.test.ts
+++ b/test/content-references.test.ts
@@ -58,8 +58,10 @@ describe('Markdown links resolve to content', () => {
   for (const file of mdxFiles) {
     const path = file.replace(/\.mdx$/, '')
     const withoutIndex = path.replace(/\/index$/, '')
-    builtRoutes.add('/' + withoutIndex)
-    if (path.endsWith('/index')) builtRoutes.add('/' + path)
+    // The `pages/` collection maps to top-level URLs (e.g. pages/about → /about)
+    const asRoute = withoutIndex.replace(/^pages\//, '')
+    builtRoutes.add('/' + asRoute)
+    if (path.endsWith('/index')) builtRoutes.add('/' + withoutIndex)
   }
 
   // Anchor-only and external links are skipped; only same-site paths matter.


### PR DESCRIPTION
## Summary

Three Phase A deliverables — small, high-leverage community-facing improvements.

### `/readers-guide` — cross-link to concept-browser deployments

Concept-browser recently added a `/learn` section explicitly positioned as "the reader-focused counterpart to glossarist.org's author docs" (commit `c20cef83`). This page makes the relationship explicit on glossarist.org and routes users to the right deployment by domain.

Lists 3 live deployments (GeoLexica, VIML, OIML Terms) with scope, languages, and the `/learn` route. Plus a section explaining what each surface teaches so users don't waste time looking for authoring docs in the reader tool, or vice versa.

Nav gains a top-level "Reader's Guide" link.

### `/docs/adopt/quickstart` — 5-minute getting-started

The existing Adoption Guide (1-workflows / 2-infrastructure / 3-migration) is thorough but slow. The Quickstart distills the first-concept workflow into 5 minutes: template → metadata → author → validate → browse. Each step has copy-paste YAML and commands. Common first-time errors called out at the validate step.

Sidebar surfaces Quickstart above the three numbered adoption steps.

### `/use-cases/standards-bodies` — aggregate cross-cutting view

The Metrology and Geospatial use cases are domain deep-dives. This new page is the cross-cutting view: a table of all six production deployments, what they share (same concept-model + libraries + concept-browser; differ only in data and config), and why standards bodies chose Glossarist over per-body custom sites.

Includes an architecture diagram showing how a fix to `concept-model` SHACL shapes propagates to every deployment on the next rebuild.

### Test invariants

- `content-references.test.ts` updated to handle the `pages/` collection correctly (`pages/X.mdx` maps to `/X`, not `/pages/X` — fixes false positives the new `/readers-guide` surface would have triggered).
- Existing invariants cover the new use case (order, domain, `/model/` cross-link) without changes.

## Test plan

- [x] `npm run build` passes — 99 pages (was 94)
- [x] `npm test` passes — 524 tests (was 509)
- [x] No AI attribution in commit
- [ ] Visual check after deploy: `/readers-guide`, `/docs/adopt/quickstart`, `/use-cases/standards-bodies`
