### PR TITLE
docs: ISO 704 §6.6 supplementary info + §7.6 term formation

### DIFF
--- a/src/content/model/supplementary-info.mdx
+++ b/src/content/model/supplementary-info.mdx
@@ -1,0 +1,161 @@
+---
+title: Supplementary Information
+description: "ISO 704:2022 §6.6 — contexts, encyclopaedic descriptions, explanations, notes, examples, and other descriptions that supplement or replace definitions. How each maps to Glossarist's LocalizedConcept fields."
+---
+
+# Supplementary Information
+
+ISO 704:2022 §6.6 names six kinds of information that can supplement or replace a definition. Glossarist models them as separate fields on `LocalizedConcept` rather than as free-text blobs — each kind has distinct authoring rules per the standard.
+
+Use these fields when a definition alone is insufficient. Especially common in ad hoc terminology work for translation, education, and scientific/technical writing, where the emphasis is on how terminology is used in practice.
+
+## The six categories
+
+| ISO 704 §6.6 | Glossarist field | When to use |
+|--------------|------------------|-------------|
+| §6.6.2 Context | `LocalizedConcept.examples[]` with `kind: context` | Cited text that lets readers infer the concept by implication |
+| §6.6.3 Encyclopaedic description | `LocalizedConcept.notes[]` with `kind: encyclopaedic` | Detail beyond essential characteristics — non-delimiting info |
+| §6.6.4 Explanation | `LocalizedConcept.notes[]` with `kind: explanation` | Paraphrase in simpler/different words |
+| §6.6.5 Note | `LocalizedConcept.notes[]` | Non-essential characteristics or optional parts |
+| §6.6.6 Example | `LocalizedConcept.examples[]` | Specific object instantiating the concept |
+| §6.6.7 Other description | `LocalizedConcept.notes[]` with `kind: other` | Historical, cultural, or usage commentary |
+
+## Contexts (§6.6.2)
+
+A **context** is a cited passage that contains the relevant designation and lets users infer the concept by implication. Typically one or more complete sentences, cited or adapted from a source. Often collected at the beginning of terminology work, before coherent definitions exist.
+
+```yaml
+localizations:
+  eng:
+    language: eng
+    terms:
+      - designation: torque wrench
+        type: expression
+        normative_status: preferred
+    definition:
+      - content: "A wrench used to apply a measured torque..."
+    examples:
+      - kind: context
+        content: "Use a torque wrench to tighten the bolts to 25 N·m per the manufacturer's specification."
+        sources:
+          - type: authoritative
+            origin: "ISO 6789-1:2017, §6.2"
+```
+
+Per ISO 704:2022 §6.6.2, contexts are valuable because they show the term in actual use, which can be more informative than a definition for ambiguous concepts.
+
+## Encyclopaedic descriptions (§6.6.3)
+
+An **encyclopaedic description** provides detail beyond the essential characteristics — non-delimiting information that enriches understanding. Distinguished from a definition: a definition's main purpose is to distinguish the concept; an encyclopaedic description's main purpose is to inform.
+
+> **EXAMPLE (ISO 704:2022 §6.6.3)** — An encyclopaedic source for *penguin* would mention that they live in the south temperate and Antarctic regions. This information is NOT part of the definition (it doesn't distinguish penguins from other birds) but it's useful encyclopaedic context.
+
+```yaml
+localizations:
+  eng:
+    notes:
+      - kind: encyclopaedic
+        content: "Penguins are found in the Southern Hemisphere, with the exception of the Galápagos penguin which lives near the equator."
+```
+
+## Explanations (§6.6.4)
+
+An **explanation** paraphrases the concept in simpler or different words, often for non-experts. Sometimes more useful than a formal definition for practical communication.
+
+```yaml
+localizations:
+  eng:
+    definition:
+      - content: "Pointing device that detects movement by means of rollers and light sensors..."
+    notes:
+      - kind: explanation
+        content: "The computer mouse, named from its shape and size, is a piece of hardware used as a pointing device for onscreen data and for executing functions by clicking its surface."
+```
+
+## Notes (§6.6.5)
+
+A **note** describes non-essential characteristics or optional parts often associated with the concept. Typically one or more complete sentences. Notes can be part of terminological entries in International Standards per ISO 10241-1.
+
+```yaml
+localizations:
+  eng:
+    definition:
+      - content: "Computer mouse in which movement is detected by light sensors."
+    notes:
+      - content: "Optical mice are available in wired and wireless options."
+```
+
+Notes that don't have a `kind` are treated as the default §6.6.5 note.
+
+## Examples (§6.6.6)
+
+An **example** demonstrates how a concept can be instantiated by a specific object. Shows a possible form of realization at the object level. Can be running text or a graphic illustration.
+
+```yaml
+localizations:
+  eng:
+    examples:
+      - content: "ISO 7010 — P004 'Warning: Guarded machinery' instantiates the concept 'single safety sign'."
+        non_verbal: /images/iso-7010-p004.svg
+```
+
+## Other descriptions (§6.6.7)
+
+Historical, cultural, or usage commentary. Often cited from existing sources. No conventional format.
+
+```yaml
+localizations:
+  eng:
+    notes:
+      - kind: other
+        content: "The Internet of Things (IoT) has broad use in industry and society today. Various IoT applications and services have adopted techniques that were not possible a few years ago..."
+        sources:
+          - type: authoritative
+            origin: "ISO/IEC 30141:2018, Introduction"
+```
+
+## When to use each
+
+| If the reader needs... | Use |
+|-----------------------|-----|
+| To see the concept in actual use | Context |
+| Non-distinguishing background detail | Encyclopaedic description |
+| A simpler paraphrase of the definition | Explanation |
+| To know about optional/related characteristics | Note |
+| A concrete instance | Example |
+| Historical or cultural commentary | Other description |
+
+## Indicating sources (§6.7)
+
+ISO 704:2022 §6.7 requires that definitions and supplementary information be accompanied by **authoritative source identifiers**. Glossarist's `ConceptSource` entity handles this — see [Sources](/model/sources).
+
+```yaml
+notes:
+  - kind: encyclopaedic
+    content: "..."
+    sources:
+      - type: authoritative
+        origin: "ISO/IEC 30141:2018, Introduction"
+```
+
+## Validator support
+
+Glossarist's `concept-shape` validator checks:
+- `examples[]` entries have `content` (non-empty)
+- `notes[]` entries have `content` (non-empty)
+- `kind` values are in the known enumeration when present
+
+What is NOT auto-checked:
+- Whether the cited source actually exists (requires cross-dataset resolution)
+- Whether the context's `content` actually contains the designation (would require NLP)
+
+These are reviewer concerns.
+
+## See also
+
+- [Definitions](/model/definitions) — what these supplements complement
+- [Concepts](/model/concepts) — `LocalizedConcept.notes` / `examples` field reference
+- [Sources](/model/sources) — `ConceptSource` for source attribution
+- [Non-verbal Entities](/model/non-verbal) — when figures/formulas replace definitions
+- [ISO 704:2022](https://www.iso.org/standard/38109.html) §6.6 + §6.7 — the authoritative reference
+- [ISO 10241-1](https://www.iso.org/standard/40362.html) §6.6 — note and example presentation rules

--- a/src/content/model/term-formation.mdx
+++ b/src/content/model/term-formation.mdx
@@ -1,0 +1,163 @@
+---
+title: Term Formation Principles
+description: "ISO 704:2022 §7.6 — the eight principles for forming new terms, appellations, and proper names: transparency, consistency, appropriateness, conciseness, derivability, linguistic correctness, language preference, transliteration. How Glossarist applies them."
+---
+
+# Term Formation Principles
+
+ISO 704:2022 §7.6 specifies eight principles for forming new terms (and appellations and proper names). Glossarist doesn't enforce these mechanically — they're reviewer guidance — but the data model surfaces the information reviewers need (term_type, grammar, sources, lineage) to apply them.
+
+## The eight principles
+
+| § | Principle | What it requires |
+|---|-----------|------------------|
+| §7.6.2.1 | **Transparency** | The concept can be inferred (at least partially) from the term itself, without a definition |
+| §7.6.2.2 | **Consistency** | New terms follow existing term-formation patterns in the concept system |
+| §7.6.2.3 | **Appropriateness** | Well-established usage is respected, even if poorly formed |
+| §7.6.2.4 | **Conciseness** | Terms are reasonably short |
+| §7.6.2.5 | **Derivability and compoundability** | Term supports derivation (noun → verb → adjective) and compounding |
+| §7.6.2.6 | **Linguistic correctness** | Term follows the morphological, phonological, and orthographic rules of the language |
+| §7.6.2.7 | **Preference for a given natural language** | Source language choice is intentional and documented |
+| §7.6.2.8 | **Transliteration and transcription** | Cross-script forms follow ISO standards |
+
+When several designations exist for one concept, ISO 704:2022 §7.6.1 requires picking the one that satisfies the largest number of principles as the **preferred** designation.
+
+## Transparency (§7.6.2.1)
+
+A term is transparent when the concept can be inferred from its linguistic elements — usually because a key (delimiting) characteristic is expressed in the term.
+
+| Transparent | Opaque |
+|-------------|--------|
+| *torque wrench* (wrench for measuring torque) | *monkey wrench* (named after inventor "Moncky") |
+| *thermal noise* (noise from thermal agitation) | *Johnson noise* (named after J.B. Johnson) |
+| *National Commission on Terrorist Attacks Upon the United States* | *Kean-Hamilton Commission* (named after chair/vice-chair) |
+
+Avoid characteristics that change quickly with technology — otherwise the term becomes misleading when the technology evolves.
+
+## Consistency (§7.6.2.2)
+
+If existing related concepts use a particular morphological pattern, new terms should follow it. Example: if *feline* / *canine* / *bovine* are established, a new family name should follow the *-ine* suffix pattern rather than introducing *-id* or *-ian*.
+
+## Appropriateness (§7.6.2.3)
+
+Established and widely used designations, even if poorly formed or opaque, should not be changed unless there are compelling reasons. Renaming *monkey wrench* to something transparent would break decades of usage for marginal benefit.
+
+## Conciseness (§7.6.2.4)
+
+Terms should be reasonably short. *Hydraulic excavator* is preferred over *machine for excavating earth by means of hydraulic actuators*.
+
+## Derivability and compoundability (§7.6.2.5)
+
+A term should support:
+- **Derivation** — *measure* → *measurement* → *measurable* → *measurably*
+- **Compounding** — *measure* + *instrument* → *measuring instrument*
+
+If a term doesn't derive or compound cleanly, it limits expressiveness in technical writing.
+
+## Linguistic correctness (§7.6.2.6)
+
+Follow the morphological, phonological, and orthographic rules of the target language. Including:
+- Plural forms (irregular plurals like *criteria* vs *criterias*)
+- Gender agreement in gendered languages
+- Phonotactic constraints
+- Spelling standardization (e.g. *sulfur* not *sulphur* per IUPAC 1990)
+
+## Preference for a given natural language (§7.6.2.7)
+
+When a concept is named in multiple languages, the source-language choice should be intentional and documented. ISO 704:2022 doesn't mandate a single source language — but the rationale should be clear.
+
+## Transliteration and transcription (§7.6.2.8)
+
+Cross-script forms follow ISO standards:
+- [ISO 9](https://www.iso.org/standard/37241.html) — Cyrillic to Latin
+- [ISO 233](https://www.iso.org/standard/37242.html) — Arabic to Latin
+- [ISO 259](https://www.iso.org/standard/37243.html) — Hebrew to Latin
+- [ISO 3602](https://www.iso.org/standard/37245.html) — Japanese to Latin
+- [ISO 7098](https://www.iso.org/standard/37246.html) — Chinese to Latin
+
+## How Glossarist surfaces these principles
+
+The data model captures the inputs reviewers need:
+
+### `term_type` (ISO 12620 enumeration)
+
+Distinguishes full_form / abbreviation / acronym / initialism / clipped_term / short_form / transliterated_form / transcribed_form / etc. — see [Term Types](/model/term-types). Reviewers use this to apply §7.6.2.5 (derivability) and §7.6.2.8 (transliteration).
+
+```yaml
+terms:
+  - designation: H₂SO₄
+    type: formula
+    normative_status: preferred
+  - designation: sulfuric acid
+    type: expression
+    normative_status: preferred
+    term_type: full_form
+  - designation: oil of vitriol
+    type: expression
+    normative_status: deprecated
+    term_type: variant
+```
+
+### `grammar` (part_of_speech, gender, number)
+
+Supports §7.6.2.6 (linguistic correctness):
+
+```yaml
+terms:
+  - designation: entité géographique
+    type: expression
+    grammar:
+      part_of_speech: noun
+      gender: feminine
+      number: singular
+```
+
+### `dates` (designation lifecycle)
+
+Supports §7.6.2.3 (appropriateness — established usage) by tracking when a designation was accepted or deprecated:
+
+```yaml
+terms:
+  - designation: sulphuric acid
+    normative_status: deprecated
+    dates:
+      - type: accepted
+        date: "1800-01-01"
+      - type: deprecated
+        date: "1990-01-01"
+        source: "IUPAC spelling standardization"
+```
+
+### `sources` (provenance)
+
+Supports §7.6.2.7 (language preference documentation):
+
+```yaml
+terms:
+  - designation: 自由落下
+    type: expression
+    normative_status: preferred
+    sources:
+      - type: authoritative
+        origin: "JIS Z 8103:2019"
+```
+
+## Validator support
+
+Glossarist does NOT auto-enforce term-formation principles. The principles are reviewer guidance — they require human judgment about transparency, consistency, etc. What IS validated:
+
+- `term_type` values are in the ISO 12620 enumeration
+- `grammar` values are in the language-appropriate taxonomy
+- `designation` text is non-empty
+- `normative_status` is one of preferred / admitted / deprecated
+- Exactly one preferred term per language is recommended (warning if > 1)
+
+For an authoring workflow that surfaces these principles during review, see [the Validator Playground](/playground/validators) — the *designation-shape* rule flags missing fields and unknown types.
+
+## See also
+
+- [Designations](/model/designations) — the data model for terms
+- [Term Types](/model/term-types) — the ISO 12620 enumeration
+- [Definitions](/model/definitions) — what terms point at
+- [ISO 704:2022](https://www.iso.org/standard/38109.html) §7.6 — the authoritative reference (and Annex B for English term-formation methods)
+- [ISO 12620](https://www.iso.org/standard/37244.html) §A.2.1 — term type data categories

--- a/src/data/sidebars.ts
+++ b/src/data/sidebars.ts
@@ -19,6 +19,7 @@ export const sidebars: Record<string, SidebarGroup[]> = {
         { text: 'Overview', link: '/model/' },
         { text: 'Concepts', link: '/model/concepts' },
         { text: 'Definitions', link: '/model/definitions' },
+        { text: 'Supplementary Info', link: '/model/supplementary-info' },
         { text: 'Designations', link: '/model/designations' },
         { text: 'Relationships', link: '/model/relationships' },
         { text: 'Hyperedges', link: '/model/hyperedges' },
@@ -30,6 +31,7 @@ export const sidebars: Record<string, SidebarGroup[]> = {
         { text: 'Datasets & Sections', link: '/model/datasets' },
         { text: 'Non-verbal Entities', link: '/model/non-verbal' },
         { text: 'Term Types', link: '/model/term-types' },
+        { text: 'Term Formation', link: '/model/term-formation' },
       ],
     },
     {


### PR DESCRIPTION
Two more model pages completing ISO 704:2022 coverage.

- /model/supplementary-info — ISO 704 §6.6: contexts, encyclopaedic descriptions, explanations, notes, examples, other descriptions. Maps each to its Glossarist field (LocalizedConcept.notes / examples / annotations with kind discriminator).
- /model/term-formation — ISO 704 §7.6: the eight principles (transparency, consistency, appropriateness, conciseness, derivability, linguistic correctness, language preference, transliteration). Glossarist doesn't enforce these mechanically but surfaces the inputs reviewers need (term_type, grammar, dates, sources).

Both pages cross-link to Definitions, Concepts, Sources, and the relevant ISO standards.

Sidebar surfaces both new pages in the Concept Model section.

## Test plan
- [x] npm run build passes — 103 pages
- [x] npm test passes — 542 tests
- [x] No AI attribution in commit