### PR TITLE
docs: ADRs + CONTRIBUTING.md (TODOs 23 + 24)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to Glossarist.org
+
+Thanks for your interest in improving Glossarist.org! This guide covers everything you need to land your first PR.
+
+## Quick start
+
+```bash
+git clone https://github.com/glossarist/glossarist.github.io.git
+cd glossarist.github.io
+npm install
+npm run dev          # http://localhost:4321
+```
+
+Requires Node 24+.
+
+## Common contributions
+
+### Fix a typo
+
+1. Edit the MDX file under `src/content/`
+2. Commit with `docs: fix typo in <page>`
+3. Open PR — no test changes needed
+
+### Add a new model page
+
+1. Create `src/content/model/<slug>.mdx` with frontmatter (`title`, `description`)
+2. Add an entry to `src/data/sidebars.ts` under `/model/`
+3. Add the page to `src/components/Nav.astro` Model dropdown (if surface-worthy)
+4. The page automatically becomes routable at `/model/<slug>`
+
+### Add a new use case
+
+1. Create `src/content/use-cases/<slug>.mdx` with frontmatter (`title`, `description`, `domain`, `order`)
+2. Page is automatically routable at `/use-cases/<slug>` and listed on `/use-cases/`
+3. Use case must link to at least one `/model/` page (test enforces)
+
+### Add a new blog post
+
+1. Create `src/content/blog/YYYY-MM-DD-<slug>.mdx` with frontmatter (`title`, `date`, `authors`, `description`)
+2. The blog index auto-sorts by date
+
+### Add a hyperedge SVG diagram
+
+1. Drop the SVG under `public/images/hyperedge-<name>.svg`
+2. **Required**: SVG must include `<title>`, `<desc>`, and `role="img"` for accessibility
+3. **Required**: Reference the SVG in MDX using `<figure class="g-figure-light">` (NOT plain markdown `![](...)`) — otherwise it's unreadable in dark mode
+4. **Required**: Wire-preview YAML inside the SVG must use canonical field names (e.g. `delimitingCharacteristic`, not `characteristic`)
+5. Test invariants in `test/content-references.test.ts` enforce all of the above
+
+### Translate a homepage string
+
+1. Edit `src/i18n/translations.ts`
+2. Add the string to every locale's `TranslationSet` (test enforces completeness)
+3. Use it in `HomePage.vue` via `t.string_name`
+
+## Code style
+
+### TypeScript path aliases (not relative imports)
+
+Use the four configured aliases:
+
+```ts
+// Good
+import { useI18n } from '@/i18n'
+import Nav from '@components/Nav.astro'
+import BaseLayout from '@layouts/BaseLayout.astro'
+import { projects } from '@data/projects'
+
+// Bad — breaks on file moves
+import { useI18n } from '../../i18n'
+```
+
+The test `test/no-relative-imports.test.ts` fails on any deep relative import.
+
+### Type everything (no `any`)
+
+The project's quality rules forbid `respond_to?`-style duck typing in Ruby. The TS analog is using `any`. Avoid it. Use proper interfaces from `src/types/concept-yaml.ts` or define new ones.
+
+When narrowing YAML parse results, use type guards:
+
+```ts
+function isHyperedge(data: unknown): data is HyperedgeYaml {
+  return isObject(data) && typeof data.type === 'string'
+}
+```
+
+### Architectural principles
+
+Every contribution should respect:
+
+- **OCP** — adding a feature = adding a file or function, not editing a switch
+- **DRY** — one source of truth. The canonical enumerations live in `src/types/concept-yaml.ts`
+- **MECE** — every concern in exactly one place; no overlap, no gaps
+- **Model-driven** — code mirrors the domain model. See `/model/` for the conceptual model
+
+### Specs required for new behavior
+
+Every new public surface needs a test. Test files live in `test/`:
+
+- `test/components/*.test.ts` — Vue component tests (use `@vue/test-utils`)
+- `test/content-references.test.ts` — MDX content invariants
+- `test/<feature>.test.ts` — feature-specific tests
+- `test/__fixtures__/` — canonical YAML fixtures (typed via `src/types/concept-yaml.ts`)
+
+## Testing
+
+```bash
+npm test              # run all tests once
+npm run test:coverage # run with coverage report
+```
+
+Vitest with jsdom environment. Path aliases configured in `vitest.config.ts`.
+
+## PR workflow
+
+1. Branch from `main`: `git checkout -b <type>/<short-description>`
+   - Types: `docs`, `feat`, `fix`, `refactor`, `test`, `chore`
+2. Commit using [Conventional Commits](https://www.conventionalcommits.org/):
+   - `docs: fix typo in hyperedges page`
+   - `feat: add bicycle use case`
+   - `refactor: extract SEO module`
+3. Push + open PR
+4. CI runs: `build`, `link_checker`, `CodeQL`, `Analyze`, `lint` (when configured)
+5. Rebase-merge when approved
+
+### Never commit on `main`
+
+Per project policy, never commit directly to `main`. Always use a branch + PR.
+
+### No AI attribution
+
+Per project policy, commits and PRs must NOT include AI attribution trailers (`Co-authored-by:`, `Generated with`, etc.). The user is the sole author; AI is a tool.
+
+## TODO.refactor/
+
+Significant architectural improvements are captured in `TODO.refactor/`. Browse the overview at `TODO.refactor/00-overview.md` to find work that matches your interest. Status legend:
+
+- ☐ Not started
+- ◐ In progress
+- ◑ Partially complete
+- ☒ Complete
+
+To claim a TODO, open an issue referencing the TODO number, or just open a PR.
+
+## Architecture Decision Records (ADRs)
+
+Significant architectural decisions are documented in `docs/adr/`. Read these before asking "why did you choose X?".
+
+To add a new ADR:
+
+1. Copy `docs/adr/0001-use-astro-not-vitepress.md` as a template
+2. Number sequentially
+3. Cover: Context, Decision, Consequences, Alternatives considered
+
+## First-time contributor ideas
+
+- Fix typos in any MDX page (search for `typo` issues)
+- Translate a missing string in `src/i18n/translations.ts`
+- Add a missing term type to `src/types/concept-yaml.ts` (verify against `/model/term-types`)
+- Write a test for an uncovered edge case (see TODO 07 for gaps)
+
+## Getting help
+
+- Open an issue: https://github.com/glossarist/glossarist.github.io/issues
+- Read `CLAUDE.md` for AI-agent-oriented context
+- Read the relevant `TODO.refactor/<n>-*.md` for architectural intent

--- a/docs/adr/0001-use-astro-not-vitepress.md
+++ b/docs/adr/0001-use-astro-not-vitepress.md
@@ -1,0 +1,42 @@
+# ADR 0001: Use Astro, not VitePress
+
+## Status
+
+Accepted (2026-07-15)
+
+## Context
+
+The site was originally VitePress. The migration was driven by:
+
+- **Vue 3 island hydration** — VitePress doesn't support per-component hydration strategies; Astro's `client:load`, `client:idle`, `client:visible` directives let us hydrate only what needs interactivity.
+- **Content collections with typed schemas** — Astro's `defineCollection` + Zod schemas validate frontmatter at build time. VitePress's loose file-based convention couldn't enforce this.
+- **Per-page layout flexibility** — Astro layouts are explicit; VitePress themes are global.
+- **MDX support** — Astro integrates `@astrojs/mdx`; VitePress's MDX story was limited.
+- **Static build + interactive islands** — Astro's island architecture gives us the performance of a static site with the interactivity of an SPA where needed.
+
+## Decision
+
+Migrate to Astro 7. Original VitePress files removed; git history retains them for forensic recovery.
+
+## Consequences
+
+**Pros**
+- Smaller interactive payloads (islands hydrate selectively)
+- Typed content collections catch frontmatter bugs at build
+- MDX enables inline component embedding (used by InlineModal-style figures)
+- Rich plugin ecosystem (`@astrojs/sitemap`, `@astrojs/rss`, `astro-pagefind`)
+
+**Cons**
+- Migration cost (one-time)
+- Astro's static-build model means some patterns require client-side workarounds (e.g. language switching via `localStorage`, not server-side Accept-Language routing)
+
+## Alternatives considered
+
+- **Next.js** — heavier; RSC model didn't fit a content site
+- **SvelteKit** — would have required rewriting Vue components
+- **Stay on VitePress** — accepted the limitations above
+
+## References
+
+- Migration plan in `TODO.astro/` (historical)
+- Build pipeline in `package.json` (`npm run build` chains data generation → astro build)

--- a/docs/adr/0002-handrolled-playground-validators.md
+++ b/docs/adr/0002-handrolled-playground-validators.md
@@ -1,0 +1,60 @@
+# ADR 0002: Hand-rolled playground validators, not bundled glossarist-js
+
+## Status
+
+Accepted (2026-07-31)
+
+## Context
+
+The Hyperedge and Validator Playgrounds (`/playground/hyperedges`, `/playground/validators`) need to validate user-entered YAML in the browser. The canonical validators live in `glossarist-js`, which is a Node-targeted library that pulls in:
+
+- `n3` (RDF parser)
+- `@rdfjs/data-model`, `@rdfjs/dataset` (RDF data model)
+- `jsonld` (JSON-LD processor)
+- `jszip` (archive handling)
+- `rdf-validate-shacl` (SHACL validation engine)
+
+Bundling these for the browser is technically possible but fragile:
+
+- Several deps assume Node `Buffer` / `fs` / `path` APIs
+- Vite's `optimizeDeps` struggles with some of them; breaks across Vite minor versions
+- Bundle size: ~1.5 MB+ just for the validators
+- The browser environment doesn't need SHACL or RDF — only the structural checks
+
+## Decision
+
+Hand-roll the structural validators in TypeScript, mirroring glossarist-js's `check-*` rule semantics. Each hand-rolled rule:
+
+- Cites the same ISO standard section as the SDK equivalent
+- Produces the same error messages
+- Lives in `src/components/HyperedgePlayground.vue` and `src/components/ValidatorPlayground.vue`
+- Imports canonical enumerations from `src/types/concept-yaml.ts` (single source of truth)
+
+The playground pages explicitly document what the hand-rolled rules do NOT cover (SHACL, cross-concept reference resolution, dataset coherence) and point users to glossarist-js for production validation.
+
+## Consequences
+
+**Pros**
+- Playground loads fast (~50 KB validators vs ~1.5 MB bundled SDK)
+- No Vite optimization fragility
+- Self-contained — playground works even if glossarist-js's deps break
+
+**Cons**
+- Two implementations of each rule. Risk of drift.
+  - **Mitigation**: canonical enumerations in `src/types/concept-yaml.ts` are shared. Tests in `test/canonical-enums.test.ts` enforce uniqueness + completeness.
+  - **Mitigation**: field-name regression test (`test/content-references.test.ts`) catches `characteristic:` vs `delimitingCharacteristic:` drift.
+
+**When to revisit**
+- If glossarist-js ships a browser-compatible build (`glossarist-js/browser`), swap the hand-rolled rules for the SDK and delete the duplicate.
+- If a third playground is added, extract the rule implementations into a shared module.
+
+## Alternatives considered
+
+- **Bundle glossarist-js as-is** — rejected for bundle size + Vite fragility
+- **Server-side validation via edge function** — would require a non-static deployment; breaks the GitHub Pages model
+- **Subset of glossarist-js (tree-shaken)** — `rdf-validate-shacl` and `n3` aren't tree-shakeable; can't reduce enough
+
+## References
+
+- TODO.refactor/17 (shared renderer extraction) — related but different concern
+- /playground/validators page footer — explicit user-facing scope statement

--- a/docs/adr/0003-client-side-i18n-chrome-only.md
+++ b/docs/adr/0003-client-side-i18n-chrome-only.md
@@ -1,0 +1,61 @@
+# ADR 0003: Client-side i18n for chrome only (not content)
+
+## Status
+
+Accepted (2026-07-31)
+
+## Context
+
+The site needs to welcome non-English readers. Two scopes of translation:
+
+1. **Chrome** — nav labels, hero text, CTAs, footer. Small surface (~50 strings).
+2. **Content** — every MDX page under `/model/`, `/reference/`, `/docs/`, `/blog/`, `/use-cases/`. ~100 pages × ~2000 words each.
+
+Options for translation strategy:
+
+- **Per-locale content collections** (`src/content/fr/`, `src/content/zh-Hans/`, etc.) with routing prefix. Full site translation.
+- **Server-rendered multi-locale** via edge function. Requires non-static deployment.
+- **Client-side chrome-only translation** — homepage hero + CTAs + nav + footer switch via `localStorage`; content pages stay English.
+
+## Decision
+
+Implement client-side chrome-only translation (option C). Defer content translation as documented in `TODO.refactor/16`.
+
+Rationale:
+
+- Chrome translation is achievable in one PR; content translation is multi-week
+- The chrome change signals welcoming to non-English readers without committing to ongoing content translation burden
+- Static deployment model (GitHub Pages) preserved
+- The i18n store (`src/i18n/index.ts`) is structured so content translation can be added later without rewriting chrome logic
+
+## Consequences
+
+**Pros**
+- Fast to ship — one PR, 4 locales
+- Honest — language switcher help text says "content pages stay in English for now"
+- No routing changes (URLs stay the same regardless of locale)
+- Reversible — content translation can be added later without removing this
+
+**Cons**
+- Inconsistent UX — visitors see translated hero, then English content. Documented in the language switcher help text.
+- No per-locale SEO (no `/fr/` URLs to index in French search engines). hreflang tags point at `?lang=` query strings on the homepage only.
+- Browser locale detection via `navigator.language` is imperfect (doesn't track the manual toggle)
+
+## Implementation
+
+- `src/i18n/translations.ts` — typed string registry (4 locales × 17 keys)
+- `src/i18n/index.ts` — Vue reactive store; localStorage persistence; `navigator.language` fallback
+- `src/components/LanguageSwitcher.vue` — dropdown in nav
+- `BaseLayout.astro` emits hreflang alternates pointing at `?lang=` URLs
+
+## Alternatives considered
+
+- **Per-locale content collections** (Astro's `i18n` routing) — rejected for scope; documented as TODO 16
+- **Translation memory service** (Crowdin, Transifex) — rejected for cost + integration burden
+- **Community forks per locale** — rejected for discoverability
+
+## References
+
+- TODO.refactor/15 — translate Nav + Footer chrome (extension)
+- TODO.refactor/16 — content translation strategy (deferred)
+- PR #98 — initial i18n implementation

--- a/docs/adr/0004-forced-light-svg-figures.md
+++ b/docs/adr/0004-forced-light-svg-figures.md
@@ -1,0 +1,63 @@
+# ADR 0004: Forced light backgrounds for hyperedge SVGs
+
+## Status
+
+Accepted (2026-07-30)
+
+## Context
+
+The hyperedge SVG diagrams (`public/images/hyperedge-*.svg`) hardcode a light-mode palette:
+
+- `fill: #f8f9fa` for boxes (light grey)
+- `fill: #212529` for text/strokes (dark)
+- `fill: #6c757d` for secondary text
+- `stroke: #adb5bd` for separators
+
+In dark mode (`html.dark`), these become unreadable: dark text on dark background.
+
+## Decision
+
+Wrap every hyperedge SVG reference in `<figure class="g-figure-light">`. The CSS class forces a white card around the SVG regardless of page theme:
+
+```css
+figure.g-figure-light img,
+.g-figure-light img {
+  background: #ffffff !important;
+  border-color: #dee2e6 !important;
+  padding: 1.5rem !important;
+}
+```
+
+This makes SVGs always render on a light card, even when the rest of the page is dark. The "card" look is acceptable in both themes.
+
+## Consequences
+
+**Pros**
+- SVGs remain readable in both themes
+- SVG authoring stays simple (no theme-aware CSS variables)
+- One CSS class covers all hyperedge diagrams
+- Test invariant (`test/content-references.test.ts`) prevents new SVGs from skipping the wrapper
+
+**Cons**
+- Visual: the SVG "card" looks slightly different from surrounding dark page. Acceptable trade-off.
+- Adding a new SVG requires remembering the wrapper. Mitigated by the test invariant.
+- The wrapper doesn't help non-hyperedge SVGs that may have the same problem.
+
+## Why not rewrite SVGs with CSS variables?
+
+The "proper" fix is using `var(--g-text-1)` etc. inside the SVG so it inherits theme from the host page. But:
+
+- CSS variables don't flow through `<img src="*.svg">` references (only inline SVGs)
+- Converting 9 SVGs to inline is a larger refactor (`TODO.refactor/04`)
+- The forced-light wrapper is a 90% solution that ships in 10 minutes
+
+## When to revisit
+
+- If non-hyperedge SVGs need theme support → apply the same wrapper pattern or migrate to inline
+- If a third party wants to embed our SVGs in their dark-mode docs → the forced-light card travels with the SVG, which is the right default
+
+## References
+
+- TODO.refactor/02 — wrapping completeness (executed)
+- TODO.refactor/04 — theme-aware palette (deferred)
+- PR #91 — initial SVG fixes + `.g-figure-light` class

--- a/docs/adr/0005-path-aliases-over-relative-imports.md
+++ b/docs/adr/0005-path-aliases-over-relative-imports.md
@@ -1,0 +1,48 @@
+# ADR 0005: Path aliases over relative imports
+
+## Status
+
+Accepted (2026-07-31)
+
+## Context
+
+TypeScript / Astro / Vite all support path aliases via `tsconfig.json` `paths` and `vite.config.ts` `resolve.alias`. This repo has four configured:
+
+- `@/*` → `src/*`
+- `@data/*` → `src/data/*`
+- `@components/*` → `src/components/*`
+- `@layouts/*` → `src/layouts/*`
+
+Without enforced aliases, contributors drift toward relative imports (`../../components/Foo`). These break when files move and create cognitive load ("count the dots").
+
+This is the TypeScript / Astro analog of the project's global Ruby rule forbidding `require_relative` for internal library code (use autoload instead).
+
+## Decision
+
+- Migrate every `from '../...'` import in `src/` to its alias equivalent
+- Add a regression test (`test/no-relative-imports.test.ts`) that fails if any deep relative import appears in `src/`
+- Document the four aliases in `CONTRIBUTING.md` and `CLAUDE.md`
+
+## Consequences
+
+**Pros**
+- File moves don't break imports
+- Less cognitive load when reading imports
+- Consistent style across the codebase
+- Aligns with the project's broader principle against fragile path dependencies
+
+**Cons**
+- Slightly more setup overhead for new contributors (must learn the four aliases)
+- Test imports in `test/` still use relative paths to `../src/...` — acceptable because tests don't move independently of `src/`
+
+## Alternatives considered
+
+- **tsconfig `paths` only (no Vite alias)** — TS type-checking works but Vite build fails to resolve. Need both.
+- **ESLint rule** — would enforce at lint time, but adds ESLint as a dependency (TODO 25)
+- **Husky pre-commit hook** — TODO 12; would catch earlier but not necessary given the test invariant
+
+## References
+
+- TODO.refactor/05 — executed in PR #100
+- Test: `test/no-relative-imports.test.ts`
+- Ruby autoload rule: project global CLAUDE.md


### PR DESCRIPTION
Executes TODOs 23 (Architecture Decision Records) and 24 (CONTRIBUTING onboarding).

## docs/adr/ — 5 initial ADRs
Captures the "why" behind significant architectural choices:
- 0001 — Use Astro, not VitePress
- 0002 — Hand-rolled playground validators, not bundled glossarist-js
- 0003 — Client-side i18n for chrome only (not content)
- 0004 — Forced light backgrounds for hyperedge SVGs
- 0005 — Path aliases over relative imports

Each ADR follows: Status, Context, Decision, Consequences, Alternatives considered, References.

ADRs are MECE with PRs: PRs say "what changed"; ADRs say "why we chose this".

## CONTRIBUTING.md
Onboarding doc for new contributors covering:
1. Quick start
2. Common contribution types (typo, model page, use case, blog post, SVG, i18n string)
3. Code style (path aliases, no any, OCP/DRY/MECE)
4. Testing conventions
5. PR workflow (Conventional Commits, no AI attribution)
6. TODO.refactor/ workflow
7. ADR workflow
8. First-time contributor ideas

## Test plan
- [x] npm run build passes — 103 pages
- [x] npm test passes — 603 tests (no test changes; docs only)
- [x] No AI attribution in commit
