### PR TITLE
refactor: i18n enum-driven keys + BreadcrumbList wiring (TODOs 21 + 11)

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -15,6 +15,9 @@
  * Glossarist itself uses ISO 639-3 (eng/fra/zho) for localizations
  * on ManagedConcept; the chrome uses BCP 47 for the language switcher
  * because that's what browsers and hreflang tags expect.
+ *
+ * Keys are union-typed so call sites get compile-time safety:
+ *   translations[current.value][KEY_HERO_LEDE]  ← key must be TranslationKey
  */
 
 export type Locale = 'eng' | 'fra' | 'zho-Hans' | 'zho-Hant'
@@ -28,30 +31,38 @@ export const LOCALES: { code: Locale; label: string; nativeLabel: string; flag: 
 
 export const DEFAULT_LOCALE: Locale = 'eng'
 
-interface TranslationSet {
-  hero_eyebrow: string
-  hero_title_1: string
-  hero_title_2_em: string
-  hero_lede: string
-  hero_cta_primary: string
-  hero_cta_secondary: string
-  section_01_label: string
-  section_01_title_pre: string
-  section_01_title_em: string
-  section_01_title_post: string
-  section_01_lede: string
-  section_05_label: string
-  section_05_title_pre: string
-  section_05_title_em: string
-  section_05_title_post: string
-  section_05_lede_prefix: string
-  section_05_lede_link: string
-  cta_title_pre: string
-  cta_title_em: string
-  cta_title_post: string
-  language_switcher_label: string
-  language_switcher_help: string
-}
+/**
+ * Exhaustive key union for chrome strings.
+ *
+ * Adding a key = adding to this union. TypeScript then forces every
+ * locale's TranslationSet to implement it. Catches drift at compile
+ * time, not at runtime test.
+ */
+export type TranslationKey =
+  | 'hero_eyebrow'
+  | 'hero_title_1'
+  | 'hero_title_2_em'
+  | 'hero_lede'
+  | 'hero_cta_primary'
+  | 'hero_cta_secondary'
+  | 'section_01_label'
+  | 'section_01_title_pre'
+  | 'section_01_title_em'
+  | 'section_01_title_post'
+  | 'section_01_lede'
+  | 'section_05_label'
+  | 'section_05_title_pre'
+  | 'section_05_title_em'
+  | 'section_05_title_post'
+  | 'section_05_lede_prefix'
+  | 'section_05_lede_link'
+  | 'cta_title_pre'
+  | 'cta_title_em'
+  | 'cta_title_post'
+  | 'language_switcher_label'
+  | 'language_switcher_help'
+
+export type TranslationSet = Record<TranslationKey, string>
 
 export const translations: Record<Locale, TranslationSet> = {
   eng: {

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from './BaseLayout.astro'
+import { deriveBreadcrumbs } from './seo'
 
 interface Props {
   title: string
@@ -23,9 +24,10 @@ function formatDate(dateStr: string): string {
 }
 
 const authorList = formatAuthors(authors)
+const breadcrumbs = deriveBreadcrumbs(Astro.url.pathname)
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} breadcrumbs={breadcrumbs} publishedAt={date}>
   <article class="blog-post">
     <header class="blog-header">
       <div class="blog-header-inner">

--- a/src/layouts/DocLayout.astro
+++ b/src/layouts/DocLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from './BaseLayout.astro'
 import Sidebar from '@components/Sidebar.astro'
 import Outline from '@components/Outline.astro'
+import { deriveBreadcrumbs } from './seo'
 
 interface Heading {
   depth: number
@@ -30,7 +31,7 @@ const {
 const showChrome = !fullscreen
 ---
 
-<BaseLayout title={title} description={description} fullscreen={fullscreen}>
+<BaseLayout title={title} description={description} fullscreen={fullscreen} breadcrumbs={deriveBreadcrumbs(pathname)}>
   <div class:list={[
     'doc-container',
     showChrome ? 'doc-with-chrome' : 'doc-fullscreen',

--- a/src/layouts/seo/breadcrumbs.ts
+++ b/src/layouts/seo/breadcrumbs.ts
@@ -1,0 +1,60 @@
+/**
+ * Breadcrumb derivation.
+ *
+ * Maps a site-relative pathname to a BreadcrumbItem[] for the
+ * BreadcrumbList JSON-LD. The hierarchy is derived from known
+ * section prefixes — single source of truth for "what's a section".
+ *
+ * Adding a new top-level section = adding to SECTION_LABELS.
+ */
+import type { BreadcrumbItem } from './types'
+
+/** Display labels for top-level sections, keyed by URL prefix. */
+const SECTION_LABELS: Record<string, string> = {
+  '/model/': 'Concept Model',
+  '/reference/': 'Reference',
+  '/docs/': 'Docs',
+  '/blog/': 'Blog',
+  '/use-cases/': 'Use Cases',
+  '/playground/': 'Playground',
+}
+
+const SECTION_ORDER = Object.keys(SECTION_LABELS).sort((a, b) => b.length - a.length)
+
+/**
+ * Derive breadcrumbs for a pathname.
+ *
+ * Examples:
+ *   '/'                                    → []
+ *   '/model/'                              → [{ Concept Model, /model/ }]
+ *   '/model/hyperedges'                    → [{ Concept Model, /model/ }, { hyperedges, /model/hyperedges }]
+ *   '/reference/standards/iso-704'         → [{ Reference, /reference/ }, { iso-704, /reference/standards/iso-704 }]
+ *
+ * Returns empty array for the homepage (no parent breadcrumb) and
+ * for paths that don't match a known section.
+ */
+export function deriveBreadcrumbs(pathname: string): BreadcrumbItem[] {
+  if (pathname === '/' || pathname === '') return []
+
+  const prefix = SECTION_ORDER.find(p => pathname.startsWith(p))
+  if (!prefix) return []
+
+  const items: BreadcrumbItem[] = [
+    { name: SECTION_LABELS[prefix], url: prefix },
+  ]
+
+  // Add the leaf (current page) if it's not the section root
+  const leaf = pathname.slice(prefix.length).replace(/\/$/, '').replace(/\/index$/, '')
+  if (leaf && leaf !== 'index') {
+    // Capitalize first letter, replace hyphens with spaces for readability
+    const leafLabel = leaf
+      .split('/')
+      .pop()!
+      .split('-')
+      .map(seg => seg.charAt(0).toUpperCase() + seg.slice(1))
+      .join(' ')
+    items.push({ name: leafLabel, url: pathname })
+  }
+
+  return items
+}

--- a/src/layouts/seo/index.ts
+++ b/src/layouts/seo/index.ts
@@ -11,5 +11,6 @@
  */
 export { buildHeadTags, buildCanonical } from './head-tags'
 export { buildJsonLd, buildTechArticleJsonLd, buildBreadcrumbJsonLd, buildWebSiteJsonLd } from './json-ld'
+export { deriveBreadcrumbs } from './breadcrumbs'
 export { HREFLANG_LOCALES } from './types'
 export type { SeoData, SeoType, BreadcrumbItem, HreflangLocale } from './types'

--- a/test/breadcrumbs.test.ts
+++ b/test/breadcrumbs.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { deriveBreadcrumbs } from '../src/layouts/seo/breadcrumbs'
+
+describe('SEO breadcrumbs derivation', () => {
+  it('homepage has no breadcrumbs', () => {
+    expect(deriveBreadcrumbs('/')).toEqual([])
+    expect(deriveBreadcrumbs('')).toEqual([])
+  })
+
+  it('section root has just the section', () => {
+    const crumbs = deriveBreadcrumbs('/model/')
+    expect(crumbs).toEqual([{ name: 'Concept Model', url: '/model/' }])
+  })
+
+  it('leaf page has section + leaf', () => {
+    const crumbs = deriveBreadcrumbs('/model/hyperedges')
+    expect(crumbs.length).toBe(2)
+    expect(crumbs[0]).toEqual({ name: 'Concept Model', url: '/model/' })
+    expect(crumbs[1].name).toBe('Hyperedges')
+    expect(crumbs[1].url).toBe('/model/hyperedges')
+  })
+
+  it('hyphenated slugs are humanized', () => {
+    const crumbs = deriveBreadcrumbs('/reference/iso-10241-1-mapping')
+    expect(crumbs[1].name).toBe('Iso 10241 1 Mapping')
+  })
+
+  it('all known sections are recognized', () => {
+    expect(deriveBreadcrumbs('/model/').length).toBe(1)
+    expect(deriveBreadcrumbs('/reference/').length).toBe(1)
+    expect(deriveBreadcrumbs('/docs/').length).toBe(1)
+    expect(deriveBreadcrumbs('/blog/').length).toBe(1)
+    expect(deriveBreadcrumbs('/use-cases/').length).toBe(1)
+    expect(deriveBreadcrumbs('/playground/hyperedges').length).toBe(2)
+  })
+
+  it('unknown paths return empty', () => {
+    expect(deriveBreadcrumbs('/random')).toEqual([])
+    expect(deriveBreadcrumbs('/random/page')).toEqual([])
+  })
+
+  it('trailing slash handled', () => {
+    expect(deriveBreadcrumbs('/model/hyperedges/').length).toBe(2)
+  })
+
+  it('deeply nested paths show section + immediate leaf', () => {
+    // e.g. /reference/standards/iso-704 — section is "Reference", leaf
+    // is the last path segment, not the full nested chain.
+    const crumbs = deriveBreadcrumbs('/reference/standards/iso-704')
+    expect(crumbs[0].name).toBe('Reference')
+    expect(crumbs[1].name).toBe('Iso 704')
+  })
+})


### PR DESCRIPTION
Two polish items bundled.

## TODO 21 — i18n enum-driven keys
TranslationSet was an interface with 22 fields. Now uses an explicit TranslationKey union + Record<TranslationKey, string>. Compiler enforces completeness across all 4 locales.

## TODO 11 finish — BreadcrumbList JSON-LD wired
SEO module already supported BreadcrumbList; layouts weren't passing breadcrumbs. Added:
- src/layouts/seo/breadcrumbs.ts — deriveBreadcrumbs(pathname) maps path to BreadcrumbItem[] using SECTION_LABELS table
- DocLayout.astro passes deriveBreadcrumbs(pathname) to BaseLayout
- BlogLayout.astro passes breadcrumbs + publishedAt

Every model/, reference/, docs/, blog/, use-cases/, playground/ page now emits BreadcrumbList JSON-LD.

## Test plan
- [x] npm run build passes — 103 pages (BreadcrumbList emitted on hierarchical pages)
- [x] npm test passes — 611 tests (was 603)
- [x] No AI attribution