### PR TITLE
feat: theme-aware SVG dark mode via prefers-color-scheme (TODO 04)

### DIFF
--- a/public/images/hyperedge-bicycle.svg
+++ b/public/images/hyperedge-bicycle.svg
@@ -12,6 +12,21 @@
     .dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
     .delimit { stroke: #212529; stroke-width: 5; fill: none; }
     .delimit-multi { stroke: #212529; stroke-width: 5; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Comprehensive -->

--- a/public/images/hyperedge-computer-mouse.svg
+++ b/public/images/hyperedge-computer-mouse.svg
@@ -14,6 +14,21 @@
     .tooth-1 { stroke: #0c5460; stroke-width: 1.5; fill: none; }
     .tooth-2 { stroke: #8b4513; stroke-width: 1.5; fill: none; }
     .char-connector { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Genus -->

--- a/public/images/hyperedge-generalization.svg
+++ b/public/images/hyperedge-generalization.svg
@@ -14,6 +14,21 @@
     .tooth-1 { stroke: #0c5460; stroke-width: 1.5; fill: none; }
     .tooth-2 { stroke: #8b4513; stroke-width: 1.5; fill: none; }
     .char-connector { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Genus -->

--- a/public/images/hyperedge-mece-multiplicity.svg
+++ b/public/images/hyperedge-mece-multiplicity.svg
@@ -11,6 +11,21 @@
     .dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
     .bold { stroke: #212529; stroke-width: 5; fill: none; }
     .invalid { stroke: #c82333; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Header -->

--- a/public/images/hyperedge-optomechanical-mouse.svg
+++ b/public/images/hyperedge-optomechanical-mouse.svg
@@ -10,6 +10,21 @@
     .tooth-solid { stroke: #212529; stroke-width: 1.5; fill: none; }
     .tooth-dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
     .tooth-delimit { stroke: #212529; stroke-width: 5; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Comprehensive concept -->

--- a/public/images/hyperedge-partitive.svg
+++ b/public/images/hyperedge-partitive.svg
@@ -8,6 +8,21 @@
     .backline { stroke: #212529; stroke-width: 2; fill: none; }
     .tooth-solid { stroke: #212529; stroke-width: 1.5; fill: none; }
     .tooth-dashed { stroke: #212529; stroke-width: 1.5; stroke-dasharray: 4 3; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Comprehensive concept -->

--- a/public/images/hyperedge-per-file-storage.svg
+++ b/public/images/hyperedge-per-file-storage.svg
@@ -7,6 +7,21 @@
     .ext-file { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; fill: #cc8800; }
     .note { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 10px; fill: #6c757d; }
     .arrow { stroke: #495057; stroke-width: 1.2; fill: none; marker-end: url(#arr); }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <defs>

--- a/public/images/hyperedge-sequential.svg
+++ b/public/images/hyperedge-sequential.svg
@@ -10,6 +10,21 @@
     .char-label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 9px; fill: #6c757d; font-style: italic; }
     .char-text { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 9.5px; fill: #212529; }
     .arrow { stroke: #0c5460; stroke-width: 2; fill: none; marker-end: url(#seq-arr); }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <defs>

--- a/public/images/hyperedge-vehicle.svg
+++ b/public/images/hyperedge-vehicle.svg
@@ -14,6 +14,21 @@
     .tooth-1 { stroke: #0c5460; stroke-width: 1.5; fill: none; }
     .tooth-2 { stroke: #8b4513; stroke-width: 1.5; fill: none; }
     .char-connector { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 2 2; fill: none; }
+  
+    @media (prefers-color-scheme: dark) {
+      .box, .genus-box { fill: #1a1a2e !important; stroke: #dee2e6 !important; }
+      .label, .char-text { fill: #e9ecef !important; }
+      .small, .char-label, .name { fill: #adb5bd !important; }
+      .opt-name { fill: #ffc107 !important; }
+      .backline, .solid, .tooth-solid, .dashed, .tooth-dashed,
+      .delimit, .delimit-multi, .tooth-delimit { stroke: #e9ecef !important; }
+      .crit { fill: #4dabf7 !important; }
+      .char-connector { stroke: #495057 !important; }
+      .backline-1 { stroke: #4dabf7 !important; }
+      .backline-2 { stroke: #ff922b !important; }
+      .tooth-1 { stroke: #4dabf7 !important; }
+      .tooth-2 { stroke: #ff922b !important; }
+    }
   </style>
 
   <!-- Genus -->


### PR DESCRIPTION
Adds a prefers-color-scheme: dark media query to every hyperedge SVG. When OS is in dark mode, SVGs render with dark palette.

Option B from TODO.refactor/04 — works with <img src='*.svg'> references, zero JS, pure CSS.

Known limitation: follows OS preference, not the site's manual theme toggle. The .g-figure-light white card remains as fallback for manually-toggled dark mode.

9 SVGs updated. Build: 103 pages. Tests: 611 pass.