### PR TITLE
feat: RSS feed + OG image fix + RSS link in head

### DIFF
--- a/src/layouts/seo/head-tags.ts
+++ b/src/layouts/seo/head-tags.ts
@@ -37,12 +37,15 @@ export function buildHeadTags(data: SeoData): HeadTag[] {
   const isHome = data.path === '/'
   const canonical = buildCanonical(data)
   const ogType = isHome ? 'website' : (data.type ?? 'article')
-  const ogImage = data.ogImage ?? (SITE_ORIGIN + '/og-default.png')
+  const ogImage = data.ogImage ?? (SITE_ORIGIN + '/logo-glossarist.svg')
   const pageTitle = data.title === 'Glossarist' ? data.title : `${data.title} | Glossarist`
 
   const tags: HeadTag[] = [
     // Canonical
     { tag: 'link', attrs: { rel: 'canonical', href: canonical } },
+
+    // RSS feed
+    { tag: 'link', attrs: { rel: 'alternate', type: 'application/rss+xml', title: 'Glossarist Blog', href: SITE_ORIGIN + '/rss.xml' } },
 
     // hreflang alternates — only the homepage has locale variants
     // (content pages are English-only for now, per i18n PR scope)

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,19 @@
+import rss from '@astrojs/rss'
+import { getCollection } from 'astro:content'
+
+export async function GET(context: { site?: URL }) {
+  const posts = (await getCollection('blog'))
+    .sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date))
+
+  return rss({
+    title: 'Glossarist Blog',
+    description: 'Release notes, technical breakdowns, and insights from the Glossarist community — covering the concept model, the software ecosystem, and real-world terminology management.',
+    site: context.site ?? 'https://www.glossarist.org',
+    items: posts.map(post => ({
+      title: post.data.title,
+      pubDate: new Date(post.data.date),
+      description: post.data.description ?? '',
+      link: `/blog/${post.id}/`,
+    })),
+  })
+}

--- a/test/seo.test.ts
+++ b/test/seo.test.ts
@@ -38,7 +38,7 @@ describe('SEO module: buildHeadTags', () => {
 
   it('homepage emits hreflang alternates for every supported locale', () => {
     const tags = buildHeadTags(homeData)
-    const hreflangs = tags.filter(t => t.tag === 'link' && t.attrs.rel === 'alternate')
+    const hreflangs = tags.filter(t => t.tag === 'link' && t.attrs.rel === 'alternate' && 'hreflang' in t.attrs)
     expect(hreflangs.length).toBe(HREFLANG_LOCALES.length + 1)  // +1 for x-default
     const locales = hreflangs.map(t => t.attrs.hreflang)
     for (const loc of HREFLANG_LOCALES) {
@@ -49,7 +49,7 @@ describe('SEO module: buildHeadTags', () => {
 
   it('content pages do NOT emit hreflang (English-only)', () => {
     const tags = buildHeadTags(articleData)
-    const hreflangs = tags.filter(t => t.attrs.rel === 'alternate')
+    const hreflangs = tags.filter(t => t.tag === 'link' && t.attrs.rel === 'alternate' && 'hreflang' in t.attrs)
     expect(hreflangs).toEqual([])
   })
 
@@ -72,10 +72,10 @@ describe('SEO module: buildHeadTags', () => {
     expect(buildHeadTags(articleData).find(t => t.attrs.property === 'og:type')?.attrs.content).toBe('article')
   })
 
-  it('og:image defaults to og-default.png when not provided', () => {
+  it('og:image defaults to logo when not provided', () => {
     const tags = buildHeadTags(articleData)
     const img = tags.find(t => t.attrs.property === 'og:image')
-    expect(img?.attrs.content).toContain('og-default.png')
+    expect(img?.attrs.content).toContain('logo-glossarist')
   })
 })
 


### PR DESCRIPTION
## Summary

1. **RSS feed** — `/rss.xml` using @astrojs/rss (already a dependency). All blog posts sorted by date. Head includes `rel=alternate` link for feed reader discovery.
2. **OG image fix** — changed default from missing `/og-default.png` to `/logo-glossarist.svg`. TODO: generate proper 1200x630 PNG.
3. **RSS link in head** — every page emits `<link rel="alternate" type="application/rss+xml">`.

## Test plan
- [x] npm run build — 103 pages + rss.xml
- [x] npm test — 618 tests
- [x] No AI attribution
