### PR TITLE
docs: update concept-browser (0.7.101) + glossarist-js (0.4.51) versions

### DIFF
--- a/src/content/docs/software/concept-browser.mdx
+++ b/src/content/docs/software/concept-browser.mdx
@@ -7,7 +7,7 @@ description: Statically deployable SPA for browsing terminology datasets with mu
 
 A statically deployable single-page application for browsing terminology datasets. Built with Vue 3, TypeScript, and Tailwind CSS. Add new datasets with **zero code changes** — just configure `site-config.yml`.
 
-**Current version:** v0.7.67 — see the [v3.1 release announcement](/blog/2026-07-05-concept-model-v3.1) for what's new across the ecosystem.
+**Current version:** v0.7.101 — TypeScript migration underway (CLI converted, composables converting), `/learn` teaching section added, relation-types page with clickable legend labels.
 
 **Live sites:**
 
@@ -192,9 +192,13 @@ The codebase is organized around an Open-Closed Principle (OCP) **group registry
 
 This keeps the build pipeline stable as new dataset shapes and group kinds are added. See [`CLAUDE.md`](https://github.com/glossarist/concept-browser/blob/main/CLAUDE.md) for the full architectural overview.
 
-### RDF layer lives in glossarist-js (v0.7.67)
+### RDF layer lives in glossarist-js (v0.7.67+)
 
-As of v0.7.67 the in-repo `src/components/concept-rdf/` layer is gone — ~2,300 LOC of duplicate emitters, writers, and graph abstractions deleted. The Vue UI now consumes [glossarist-js](/docs/software/glossarist-js) directly: `conceptToQuads` and `provenanceToQuads` for the graph, `writeTurtleSync` + canonical prefixes for CURIE-form Turtle, and `formatJsonLd` for JSON-LD. This makes glossarist-js the single source of truth for RDF emission across the ecosystem — fixes land once and propagate to every consumer.
+As of v0.7.67 the in-repo `src/components/concept-rdf/` layer is gone — ~2,300 LOC of duplicate emitters, writers, and graph abstractions deleted. The Vue UI now consumes [glossarist-js](/docs/software/glossarist-js) v0.4.51+ directly: `conceptToQuads` and `provenanceToQuads` for the graph, `writeTurtleSync` + canonical prefixes for CURIE-form Turtle, and `formatJsonLd` for JSON-LD. This makes glossarist-js the single source of truth for RDF emission across the ecosystem — fixes land once and propagate to every consumer.
+
+### TypeScript migration (v0.7.101+)
+
+The CLI (`cli/index.ts`) is now fully typed TypeScript. The composables (`src/composables/*.ts`) are converting. A 15-item roadmap (`TODO.typescript/`) tracks progress. The glossarist-js upgrade to v0.4.51 achieved zero TypeScript errors across the codebase.
 
 ## Links
 

--- a/src/content/docs/software/glossarist-js.mdx
+++ b/src/content/docs/software/glossarist-js.mdx
@@ -7,7 +7,7 @@ description: JavaScript SDK for Glossarist GCR packages — read, write, validat
 
 JavaScript SDK for reading and writing [Glossarist](https://github.com/glossarist) GCR packages — manages terminology concepts with rich domain models, bidirectional YAML serialization, validation, cross-reference resolution, RDF serializers, and SHACL validation.
 
-**Current version:** v0.4.15 — full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model v3.1.0](/blog/2026-07-05-concept-model-v3.1).
+**Current version:** v0.4.51 — Phase 1 model additions (SequentialHyperedge, concept_type, AppellationDesignation, definition-rule validators), TypeScript type exports improved, zero type errors in concept-browser. Full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model](https://github.com/glossarist/concept-model) Phase 1.
 
 ## Install
 


### PR DESCRIPTION
Stale version references fixed. concept-browser was at v0.7.67 in docs (actual: v0.7.101). glossarist-js was at v0.4.15 (actual: v0.4.51). Added TypeScript migration section to concept-browser docs.

## Test plan
- [x] npm run build — 103 pages
- [x] npm test — 618 tests
- [x] No AI attribution