### PR TITLE
refactor: glossarist-js TS completion docs + TODO 26 (type integration plan)

### DIFF
--- a/TODO.refactor/00-overview.md
+++ b/TODO.refactor/00-overview.md
@@ -53,11 +53,14 @@ This directory captures every architectural, code-quality, and feature enhanceme
 
 | # | Title | Status |
 |---|-------|--------|
-| 13 | [Accessibility WCAG 2.1 AA audit](13-accessibility-wcag-audit.md) | ☐ |
-| 14 | [Image optimization — responsive WebP, lazy-loading audit](14-image-optimization.md) | ☐ |
-| 15 | [Translate Nav + Footer chrome (i18n extension)](15-translate-nav-footer-chrome.md) | ☐ |
-| 16 | [Content translation strategy (per-locale content collections)](16-content-translation-strategy.md) | ☐ |
-| 17 | [Shared concept-browser renderer extraction](17-shared-renderer-extraction.md) | ☐ |
+| 13 | [Accessibility WCAG 2.1 AA audit](13-accessibility-wcag-audit.md) | ☒ |
+| 14 | [Image optimization — responsive WebP, lazy-loading audit](14-image-optimization.md) | ☒ |
+| 15 | [Translate Nav + Footer chrome (i18n extension)](15-translate-nav-footer-chrome.md) | ☒ |
+| 16 | [Content translation strategy (per-locale content collections)](16-content-translation-strategy.md) | ☒ |
+| 17 | [Shared concept-browser renderer extraction](17-shared-renderer-extraction.md) | ☒ |
+| 18 | [Split HomePage.vue into composed sections](18-split-homepage-into-composed-sections.md) | ◑ |
+| 25 | [ESLint + Prettier config](25-eslint-prettier-config.md) | ☒ |
+| 26 | [Import glossarist-js types when *Json interfaces are public](26-import-glossarist-js-types.md) | ☐ |
 
 ## Execution order
 

--- a/TODO.refactor/26-import-glossarist-js-types.md
+++ b/TODO.refactor/26-import-glossarist-js-types.md
@@ -1,0 +1,69 @@
+# TODO 26 — Import glossarist-js types when *Json interfaces are public
+
+## Status
+☐ Not started — blocked on glossarist-js re-exporting `*Json` interfaces from its public API
+
+## Motivation
+
+glossarist-js v0.4.51 is now fully TypeScript. It exports:
+- Runtime model classes: `Concept`, `PartitiveHyperedge`, `PartitiveMember`, `GenericMember`, etc.
+- Enum constants: `RELATIONSHIP_TYPES`, `PARTITIVE_ENUMERATION_VALUES`, etc.
+- Internal `*Json` interfaces: `ConceptJson`, `AbstractHyperedgeJson`, `ConceptRefJson`, etc.
+
+The `*Json` interfaces are used internally by model constructors and `toJSON()`/`fromJSON()` methods. They describe the exact wire/YAML shape — which is what our hand-rolled `src/types/concept-yaml.ts` also describes.
+
+Currently our hand-rolled types can drift from the SDK. If glossarist-js adds a field, our types won't know until someone manually updates them.
+
+## What's needed from glossarist-js
+
+glossarist-js should re-export its `*Json` interfaces from `src/models/index.ts`:
+
+```ts
+// src/models/index.ts addition:
+export type { ConceptJson } from './concept.js';
+export type { LocalizedConceptJson } from './localized-concept.js';
+export type { AbstractHyperedgeJson } from './abstract-hyperedge.js';
+export type { HyperedgeMemberJson } from './hyperedge-member.js';
+export type { ConceptRefJson } from './concept-ref.js';
+export type { RelatedConceptJson } from './related-concept.js';
+// ... etc
+```
+
+Then the root `src/index.ts` already re-exports from `./models/index.js`, so these become available at `import type { ConceptJson } from 'glossarist'`.
+
+## What we'll do when unblocked
+
+Replace `src/types/concept-yaml.ts` with:
+
+```ts
+// src/types/concept-yaml.ts (rewritten as thin re-exports)
+export type {
+  ConceptJson as ConceptYaml,
+  AbstractHyperedgeJson as HyperedgeYaml,
+  HyperedgeMemberJson as HyperedgeMemberYaml,
+  ConceptRefJson as ConceptRef,
+} from 'glossarist'
+
+export { RELATIONSHIP_TYPES as RELATED_TYPE_ENUM } from 'glossarist'
+```
+
+This eliminates ~250 lines of hand-rolled types and makes us a pure consumer of the SDK's type definitions. Adding a field to glossarist-js automatically appears in our types.
+
+## Why not install glossarist as a dependency now?
+
+Installing glossarist pulls in n3, @rdfjs/data-model, @rdfjs/dataset, jsonld, jszip, rdf-validate-shacl — ~5MB of Node-targeted deps. Even though `import type` is erased at compile time (zero runtime cost), the install bloats node_modules and may confuse Vite's dependency optimizer.
+
+When glossarist-js ships a browser-safe type-only subpath (`glossarist/types`), this concern goes away. Until then, the hand-rolled types are the pragmatic choice.
+
+## Acceptance criteria
+
+- [ ] glossarist-js re-exports `*Json` interfaces from public API
+- [ ] glossarist-js ships `glossarist/types` subpath (type-only, zero runtime deps)
+- [ ] Our `src/types/concept-yaml.ts` becomes thin re-exports
+- [ ] Cross-repo test verifies enum values match
+- [ ] All existing tests pass with the SDK types
+
+## Dependencies
+
+- glossarist-js PR to re-export `*Json` interfaces
+- glossarist-js PR to add `glossarist/types` subpath export

--- a/src/content/docs/software/concept-browser.mdx
+++ b/src/content/docs/software/concept-browser.mdx
@@ -196,9 +196,9 @@ This keeps the build pipeline stable as new dataset shapes and group kinds are a
 
 As of v0.7.67 the in-repo `src/components/concept-rdf/` layer is gone — ~2,300 LOC of duplicate emitters, writers, and graph abstractions deleted. The Vue UI now consumes [glossarist-js](/docs/software/glossarist-js) v0.4.51+ directly: `conceptToQuads` and `provenanceToQuads` for the graph, `writeTurtleSync` + canonical prefixes for CURIE-form Turtle, and `formatJsonLd` for JSON-LD. This makes glossarist-js the single source of truth for RDF emission across the ecosystem — fixes land once and propagate to every consumer.
 
-### TypeScript migration (v0.7.101+)
+### TypeScript migration (v0.7.101+) — COMPLETE
 
-The CLI (`cli/index.ts`) is now fully typed TypeScript. The composables (`src/composables/*.ts`) are converting. A 15-item roadmap (`TODO.typescript/`) tracks progress. The glossarist-js upgrade to v0.4.51 achieved zero TypeScript errors across the codebase.
+The CLI (`cli/index.ts`), composables (`src/composables/*.ts`), and all Vue components are now fully typed TypeScript. The glossarist-js upgrade to v0.4.51 achieved zero TypeScript errors across the codebase. A `/learn` teaching section provides reader-focused guides to the site's terminology concepts.
 
 ## Links
 

--- a/src/content/docs/software/glossarist-js.mdx
+++ b/src/content/docs/software/glossarist-js.mdx
@@ -7,7 +7,7 @@ description: JavaScript SDK for Glossarist GCR packages — read, write, validat
 
 JavaScript SDK for reading and writing [Glossarist](https://github.com/glossarist) GCR packages — manages terminology concepts with rich domain models, bidirectional YAML serialization, validation, cross-reference resolution, RDF serializers, and SHACL validation.
 
-**Current version:** v0.4.51 — Phase 1 model additions (SequentialHyperedge, concept_type, AppellationDesignation, definition-rule validators), TypeScript type exports improved, zero type errors in concept-browser. Full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model](https://github.com/glossarist/concept-model) Phase 1.
+**Current version:** v0.4.51 — **fully TypeScript** (source files are `.ts`, compiled `.d.ts` shipped). Phase 1 model additions (SequentialHyperedge, concept_type, AppellationDesignation, definition-rule validators). Full model parity with [glossarist-ruby](/docs/software/glossarist-ruby), synced to [concept-model](https://github.com/glossarist/concept-model) Phase 1.
 
 ## Install
 


### PR DESCRIPTION
## Summary

glossarist-js v0.4.51 is now fully TypeScript. concept-browser TS migration is COMPLETE. This PR:
1. Updates concept-browser docs (TS migration: "underway" → "COMPLETE")
2. Updates glossarist-js docs (adds "fully TypeScript" qualifier)
3. Adds TODO.refactor/26 — plan to replace hand-rolled types with glossarist-js imports (blocked on *Json interfaces being re-exported from public API)
4. Updates TODO overview status (13-17, 25 now ☒; 26 added)
5. Confirms MECE 3-axis model is correctly reflected everywhere (exhaustive audit of 27 files)

## Test plan
- [x] npm run build — 103 pages
- [x] npm test — 618 tests
- [x] No AI attribution
