### PR TITLE
docs: add concept-browser architecture page

### DIFF
--- a/src/content/model/concept-browser.mdx
+++ b/src/content/model/concept-browser.mdx
@@ -1,0 +1,113 @@
+---
+title: Concept Browser Architecture
+description: "How concept-browser turns YAML datasets into a browsable terminology site — data pipeline, citation resolution, TypeScript layers, and deployment model."
+---
+
+# Concept Browser Architecture
+
+Concept-browser is a statically deployable terminology browser. You install it as an npm package, point it at your YAML datasets, run `build`, and deploy the output to any static host. No server, no runtime dependencies, no database.
+
+## Data pipeline
+
+```
+Author YAML                Build pipeline              Browser
+─────────────              ───────────────              ──────────────────
+
+concepts/*.yaml  ──────┐
+bibliography.yaml ─────┤    scripts/generate-data.ts    src/adapters/model-bridge.ts
+figures/          ─────┼──> │  harmonize concepts      │ ──>  Concept instances  ──>  Vue SPA
+tables/           ─────┤    │  emit JSON-LD + RDF      │      (glossarist-js)
+site-config.yml   ─────┘    │  build manifest + edges  │
+                           │  copy assets             │
+                           └──────────────────────────┘
+                                      │
+                                      ▼
+                               dist/ (static files)
+                               ├── data/{id}/concepts/*.json
+                               ├── data/{id}/manifest.json
+                               └── data/{id}/*.ttl (RDF)
+```
+
+### What each script does
+
+| Script | Responsibility |
+|--------|---------------|
+| `generate-data.ts` | Orchestrator: YAML → JSON-LD + RDF + manifest |
+| `build-edges.ts` | Pre-compute cross-reference edges between concepts |
+| `bridge-to-astro.ts` | Bridge generated data to Astro content collections |
+| `process-about-pages.ts` | Compile markdown/AsciiDoc about pages |
+| `generate-ontology-data.ts` | Parse OWL ontology into browsable JSON |
+| `generate-ontology-schema.ts` | Extract SHACL shapes from ontology |
+
+## TypeScript layers
+
+All code is TypeScript, with two graduated strictness levels:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ tsconfig.json (strict)        tsconfig.scripts.json (relaxed)   │
+│ ┌──────────────────────┐      ┌──────────────────────────────┐  │
+│ │ src/**/*.vue         │      │ scripts/**/*.ts              │  │
+│ │ src/**/*.ts (prod)   │      │ cli/**/*.ts                  │  │
+│ └──────────────────────┘      └──────────────────────────────┘  │
+│   vue-tsc checks this           tsc -p tsconfig.scripts.json   │
+│   during `npm run build`        checks scripts separately      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Wire types
+
+Three MECE layers describe the data shapes that cross system boundaries:
+
+| Layer | File | What it types |
+|-------|------|---------------|
+| YAML author format | `scripts/lib/yaml-types.ts` | What dataset authors write |
+| JSON-LD browser format | `src/adapters/jsonld-types.ts` | What the SPA reads |
+| Runtime model | `glossarist` npm package | Concept, LocalizedConcept, etc. |
+
+Single barrel at `src/adapters/wire/index.ts` re-exports all three layers — one import path for consumers.
+
+### The model-bridge
+
+`src/adapters/model-bridge.ts` converts JSON-LD wire objects → glossarist-js `Concept` instances. All downstream Vue components work exclusively with `Concept` instances — they never touch raw JSON-LD.
+
+This means:
+- Changing the wire format (e.g., renaming a `gl:*` key) is a one-place edit in the bridge
+- Adding a new glossarist-js field is a one-place edit in the bridge
+- Vue components are insulated from wire-format evolution
+
+## Citation resolution
+
+When concept text contains `{{cite:sourceId}}`, the browser walks a 4-step cascade:
+
+1. **uriPatterns** — Is there a co-deployed dataset whose URI matches? → internal link
+2. **routing[]** — Is there a routing entry in `site-config.yml`? → external link
+3. **citation.link** — Does the source have a canonical link? → flat bibliography record
+4. **unresolved** — plain text
+
+The same citation resolves differently depending on deployment. A dataset author writes `{{cite:iso704}}` without knowing where their dataset will be deployed — the deployer's `site-config.yml` decides.
+
+## Deployment model
+
+```
+Your project (CWD)                    Package (read-only)
+├── site-config.yml          ──┐
+├── datasets/                 ─┤
+│   └── my-vocab/             ─┤     ┌──────────────────────────┐
+│       └── concepts/*.yaml   ─┤     │ @glossarist/concept-browser │
+├── public/                   ─┤ ──> │                          │
+│   └── (logos, favicons)     ─┤     │ generate-data.ts         │
+├── .cb-content/   ← generated │     │ bridge-to-astro.ts       │
+└── dist/          ← output    │     │ astro build              │
+                             ──┘     └──────────────────────────┘
+```
+
+The package is **read-only after installation**. All generated output goes to the consumer's working directory (`.cb-content/` and `dist/`). The package directory (`node_modules/`) is never modified — this is a core principle of library packages.
+
+## Further reading
+
+- [Inline Mentions](/model/inline-mentions) — the `{{kind:target}}` syntax
+- [Concepts](/model/concepts) — the concept data model
+- [Relationships](/model/relationships) — bilateral and hyperedge relations
+- [Hyperedges](/model/hyperedges) — pipe-and-thread visualization
+- [Sources](/model/sources) — concept provenance and citations

--- a/src/content/model/inline-mentions.mdx
+++ b/src/content/model/inline-mentions.mdx
@@ -1,0 +1,105 @@
+---
+title: Inline Mentions
+description: "Unified {{kind:target}} syntax for inline references in concept text — citations, URNs, figures, tables, formulas, bibliography, external links, images, and concept designations."
+---
+
+# Inline Mentions
+
+Inline references in concept text (definitions, notes, examples) use a **unified mention syntax**: `{{kind:target}}`. Every mention is typed — the kind prefix determines how concept-browser resolves and renders it.
+
+## The mental model
+
+> Everything in `{{...}}` is a typed reference or embed. The first word (before `:`) tells you what kind. The rest is the target identifier. Optionally, a comma + label gives the display text.
+
+## Kind reference
+
+| Kind | Syntax | Example | Resolves to |
+|------|--------|---------|-------------|
+| `cite` | `{{cite:id}}` | `{{cite:iso704}}` | A `ConceptSource` in this concept's `sources[]` (by `id`) — walks the full resolution cascade |
+| `cite` + label | `{{cite:id, label}}` | `{{cite:iso704, rice}}` | Same, with explicit display text |
+| `urn` | `{{urn:URN}}` | `{{urn:iso:std:iso:704}}` | A concept via URN routing |
+| `fig` | `{{fig:id}}` | `{{fig:diagram_3}}` | A figure entity in the same dataset |
+| `table` | `{{table:id}}` | `{{table:units}}` | A table entity |
+| `formula` | `{{formula:id}}` | `{{formula:ohm_law}}` | A formula entity |
+| `bib` | `{{bib:id}}` | `{{bib:ref_1}}` | A bibliography entry (no underlying concept) |
+| `link` | `{{link:URL}}` | `{{link:https://example.com}}` | An external URL (canonical, deployment-independent) |
+| `image` | `{{image:src}}` | `{{image:diagram.png}}` | An inline image embed |
+| *(none)* | `{{designation}}` | `{{measurement unit}}` | A concept by designation match (same dataset) |
+| *(none)* | `{{numeric}}` | `{{112-01-10}}` | A concept by numeric ID (same dataset) |
+
+## Data / Deployment Boundary
+
+Mention syntax is **deployment-agnostic**. The dataset author writes the same mention regardless of where the dataset will be deployed.
+
+The **deployment** (via `site-config.yml`) determines how each mention resolves:
+
+1. **Is the target in a co-deployed dataset?** → internal link (case 1)
+2. **Is the target in the routing table?** → external link (case 2)
+3. **Does the source have a canonical link?** → flat bib record (case 3)
+4. **No match** → plain text
+
+The same YAML renders differently in different deployments. The data never changes.
+
+## Citation resolution cascade
+
+For `{{cite:id}}` and `{{urn:...}}` mentions, concept-browser walks this cascade at render time:
+
+| Step | Check | Result |
+|------|-------|--------|
+| 1 | `uriPatterns` — co-deployed dataset match? | **Internal** link to local concept page |
+| 2 | `routing[]` — external routing entry? | **External** link to routed URL |
+| 3 | `citation.link` — canonical source link? | **Self-contained** flat bib record |
+| 4 | (no match) | **Unresolved** — plain text |
+
+## Cite mentions
+
+`{{cite:sourceId}}` looks up a `ConceptSource` in the concept's own `sources[]` list by its `id` field:
+
+::: v-pre
+```yaml
+sources:
+  - id: iso-704
+    type: authoritative
+    origin:
+      ref: { source: ISO, id: "704", version: "2009" }
+      link: https://www.iso.org/standard/38109.html
+
+definition:
+  - content: >-
+      Concepts are identified by their characteristics
+      (see {{cite:iso-704}} §3.2).
+```
+:::
+
+The citation resolves through the full cascade. If ISO 704 is co-deployed, it links locally. If only the routing table knows about it, it links externally. If neither, it renders as a flat reference with the `link` URL.
+
+See [Authoritative Sources](/model/sources) for the full `ConceptSource` model.
+
+## External links and images
+
+`{{link:URL}}` and `{{image:src}}` are for resources **external to all datasets**. The URL/src is the canonical target — the deployment has nothing to decide.
+
+::: v-pre
+```yaml
+definition:
+  - content: >-
+      See {{link:https://www.iso.org/obp/ui/#iso:std:iso:704:ed-3:v1:en, ISO 704 online}}
+      for the full standard text.
+
+      The measurement setup is shown in {{image:setup.png, Measurement apparatus}}.
+```
+:::
+
+## Deprecated: `<<ref,title>>`
+
+The AsciiDoc xref syntax `<<ref,title>>` is deprecated. It emits a console warning and renders as plain text. Migrate to the unified syntax:
+
+- `<<fig_3, Figure 3>>` → `{{fig:fig_3, Figure 3}}`
+- `<<845-01-01, 845-01-01>>` → `{{cite:iev_845-01-01}}`
+- `<<ref_1, ISO 704>>` → `{{bib:ref_1, ISO 704}}`
+
+## Related
+
+- [Authoritative Sources](/model/sources) — the `ConceptSource` model and citation cascade
+- [Non-verbal entities](/model/non-verbal) — figure/table/formula entities
+- [Datasets](/model/datasets) — dataset identity and URN routing

--- a/src/content/model/inline-mentions.mdx
+++ b/src/content/model/inline-mentions.mdx
@@ -100,6 +100,7 @@ The AsciiDoc xref syntax `<<ref,title>>` is deprecated. It emits a console warni
 
 ## Related
 
+- [Concept Browser Architecture](/model/concept-browser) — how mentions resolve at runtime
 - [Authoritative Sources](/model/sources) — the `ConceptSource` model and citation cascade
 - [Non-verbal entities](/model/non-verbal) — figure/table/formula entities
 - [Datasets](/model/datasets) — dataset identity and URN routing


### PR DESCRIPTION
## Summary

Adds `/model/concept-browser` — a new page documenting how concept-browser works:
- Data pipeline (YAML → JSON-LD → RDF → static site)
- TypeScript architecture (graduated tsconfig, wire types barrel)
- Citation resolution cascade (4-step fallback)
- Deployment model (read-only package, consumer-owned output)

Cross-linked from `/model/inline-mentions`.

## Test plan

- [x] `npm test` — 624/624 pass
- [x] New page will be auto-discovered by Astro content collections glob loader